### PR TITLE
feat: add consumed capacity to update response

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,11 @@ Account.update({email: 'foo@example.com', name: 'Bar Tester'}, {ReturnValues: 'A
   console.log('update account', acc.get('name')); // prints the old account name
 });
 
+// Return the consumed capacity of this update
+Account.update({email: 'foo@example.com', name: 'Bar Tester'}, {ReturnConsumedCapaity: 'INDEXES'}, function (err, acc, consumedCapacity) {
+  console.log('update account', consumedCapacity); // prints the consumed capacity
+});
+
 // Only update the account if the current age of the account is 21
 Account.update({email: 'foo@example.com', name: 'Bar Tester'}, {expected: {age: 22}}, function (err, acc) {
   console.log('update account', acc.get('name'));

--- a/lib/table.js
+++ b/lib/table.js
@@ -304,16 +304,17 @@ Table.prototype.update = function (item, options, callback) {
       }
 
       let result = null;
+      let consumedCapacity = null;
       if (data.Attributes) {
         result = self.initItem(self.serializer.deserializeItem(data.Attributes));
       }
 
       if (data.ConsumedCapacity) {
-        result.ConsumedCapacity = data.ConsumedCapacity;
+        consumedCapacity = data.ConsumedCapacity;
       }
 
-      self._after.emit('update', result);
-      return callback(null, result);
+      self._after.emit('update', result, consumedCapacity);
+      return callback(null, result, consumedCapacity);
     });
   });
 };

--- a/lib/table.js
+++ b/lib/table.js
@@ -307,7 +307,7 @@ Table.prototype.update = function (item, options, callback) {
       if (data.Attributes) {
         result = self.initItem(self.serializer.deserializeItem(data.Attributes));
       }
-      
+
       if (data.ConsumedCapacity) {
         result.ConsumedCapacity = data.ConsumedCapacity;
       }

--- a/lib/table.js
+++ b/lib/table.js
@@ -307,6 +307,10 @@ Table.prototype.update = function (item, options, callback) {
       if (data.Attributes) {
         result = self.initItem(self.serializer.deserializeItem(data.Attributes));
       }
+      
+      if (data.ConsumedCapacity) {
+        result.ConsumedCapacity = data.ConsumedCapacity;
+      }
 
       self._after.emit('update', result);
       return callback(null, result);


### PR DESCRIPTION
When updating an item, there is the option to return the consumed capacity.
http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateItem.html#DDB-UpdateItem-request-ReturnConsumedCapacity
If it is returned, it is appended to the response under the `ConsumedCapacity` key.
