### PR TITLE
Don't mutate options parameter when updating table

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -335,27 +335,15 @@ Table.prototype.update = function (item, options, callback) {
       return callback(e);
     }
 
-    if (exp.UpdateExpression) {
-      params.UpdateExpression = exp.UpdateExpression;
-      delete options.UpdateExpression;
-    }
-
-    if (exp.ExpressionAttributeValues) {
-      params.ExpressionAttributeValues = exp.ExpressionAttributeValues;
-      delete options.ExpressionAttributeValues;
-    }
-
-    if (exp.ExpressionAttributeNames) {
-      params.ExpressionAttributeNames = exp.ExpressionAttributeNames;
-      delete options.ExpressionAttributeNames;
-    }
+    params = _.assign(params, exp);
 
     if (options.expected) {
       internals.addConditionExpression(params, options.expected);
-      delete options.expected;
     }
 
-    params = _.chain({}).merge(params, options).omitBy(_.isEmpty).value();
+    const unprocessedOptions = _.omit(options, ['UpdateExpression', 'ExpressionAttributeValues', 'ExpressionAttributeNames', 'expected']);
+
+    params = _.chain({}).merge(params, unprocessedOptions).omitBy(_.isEmpty).value();
 
     self.sendRequest('update', params, (err, data) => {
       if (err) {

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -773,13 +773,21 @@ describe('table', () => {
 
       docClient.update.withArgs(request).yields(null, { Attributes: returnedAttributes });
 
-      table.update(item, { ReturnValues: 'ALL_OLD', expected: { name: 'Foo Bar' } }, (err, account) => {
+      const getOptions = function () {
+        return { ReturnValues: 'ALL_OLD', expected: { name: 'Foo Bar' } };
+      };
+
+      const passedOptions = getOptions();
+
+      table.update(item, passedOptions, (err, account) => {
         account.should.be.instanceof(Item);
 
         account.get('email').should.equal('test@test.com');
         account.get('name').should.equal('Tim Test');
         account.get('age').should.equal(23);
         account.get('scores').should.eql([97, 86]);
+
+        expect(passedOptions).to.deep.equal(getOptions());
 
         done();
       });


### PR DESCRIPTION
Thanks for the awesome package!

I noticed that `table#update` was unexpectedly mutating the `options` parameter, which can cause silent bugs. For example, if we want to log all the times where an item we want to update does not exist, we might write something like:

```javascript
let options = { expected: { id: { Exists: true }}};
for (let model in modelsToUpdate) {
  model.update(updateObject, options, function(err, updatedModel) {
    if (err) {
      logger.warn('Model not found');
    }
  });
}
```

This code does not log as intended because the `expected` key is deleted from the `options` object after the first update. In this PR I propose making use of lodash to avoid mutating the `options` parameter and simplify the code slightly. Thanks for looking!