### PR TITLE
Give name and detail to table update schema validation error

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -297,7 +297,10 @@ Table.prototype.update = function (item, options, callback) {
 
   const schemaValidation = internals.validateItemFragment(item, self.schema);
   if (schemaValidation.error) {
-    return callback(new Error(JSON.stringify(schemaValidation.error)));
+    return callback(_.assign(new Error(`Schema validation error while updating item in table ${self.tableName()}: ${JSON.stringify(schemaValidation.error)}`), {
+        name: 'DynogelsUpdateError',
+        detail: schemaValidation.error
+    }));
   }
 
   const start = callback => {


### PR DESCRIPTION
This change allows update failures due to schema validation errors to be differentiated by the error's `name` attribute, and also exposes the error detail object so that, for example, REST APIs can indicate exactly what errors are present in the JSON payload.

This change partially fixes #73, but there are a few more `new Error` instances in the rest of the codebase that need to be addressed.