### PR TITLE
Allow access to table schema from model

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -106,6 +106,7 @@ internals.compileModel = (name, schema) => {
   Model.before = _.bind(table.before, table);
 
   Model.__defineGetter__('docClient', () => table.docClient);
+  Model.__defineGetter__('schema', () => table.schema);
 
   Model.config = config => {
     config = config || {};


### PR DESCRIPTION
Use case: Writing a maintenance script to add fiends to a model, writing a generic method that takes the model as a parameter and using the `Model.schema.hashKey` to get the hash key name in order to update records.