### PR TITLE
Remove logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1092,24 +1092,8 @@ var Event = dynogels.define('Event', {
 ```
 
 ### Logging
-Logging can be enabled to provide detailed information on data being sent and returned from DynamoDB.
-[Bunyan](https://github.com/trentm/node-bunyan) is used for logging internally.
-By default logging is turned off.
 
-```js
-dynogels.log.level('info'); // enabled INFO log level
-```
-
-Logging can also be enabled / disabled at the model level.
-
-```js
-var Account = dynogels.define('Account', {hashKey : 'email'});
-var Event = dynogels.define('Account', {hashKey : 'name'});
-
-Account.log.level('warn'); // enable WARN log level for Account model operations
-```
-
-* [Bunyan log levels](https://github.com/trentm/node-bunyan#levels)
+Logging has been removed. Debug with devtools, node debug, or edit your locally-installed source and put temporary console.log statements as needed.
 
 ## Examples
 

--- a/lib/createTables.js
+++ b/lib/createTables.js
@@ -9,28 +9,21 @@ internals.createTable = (model, globalOptions, options, callback) => {
   globalOptions = globalOptions || {};
   options = options || {};
 
-  const tableName = model.tableName();
-
   model.describeTable((err, data) => {
     if (_.isNull(data) || _.isUndefined(data)) {
-      model.log.info('creating table: %s', tableName);
       return model.createTable(options, error => {
         if (error) {
-          model.log.warn({ err: error }, 'failed to create table %s: %s', tableName, error);
           return callback(error);
         }
 
-        model.log.info('waiting for table: %s to become ACTIVE', tableName);
         internals.waitTillActive(globalOptions, model, callback);
       });
     } else {
       model.updateTable(err => {
         if (err) {
-          model.log.warn({ err: err }, 'failed to update table %s: %s', tableName, err);
           return callback(err);
         }
 
-        model.log.info('waiting for table: %s to become ACTIVE', tableName);
         internals.waitTillActive(globalOptions, model, callback);
       });
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,19 +10,12 @@ const serializer = require('./serializer');
 const batch = require('./batch');
 const Item = require('./item');
 const createTables = require('./createTables');
-const bunyan = require('bunyan');
 
 const dynogels = module.exports;
 
 dynogels.AWS = AWS;
 
 const internals = {};
-
-dynogels.log = bunyan.createLogger({
-  name: 'dynogels',
-  serializers: { err: bunyan.stdSerializers.err },
-  level: bunyan.FATAL
-});
 
 dynogels.dynamoDriver = internals.dynamoDriver = driver => {
   if (driver) {
@@ -69,9 +62,7 @@ internals.compileModel = (name, schema) => {
   // extremly simple table names
   const tableName = `${name.toLowerCase()}s`;
 
-  const log = dynogels.log.child({ model: name });
-
-  const table = new Table(tableName, schema, serializer, internals.loadDocClient(), log);
+  const table = new Table(tableName, schema, serializer, internals.loadDocClient());
 
   const Model = function (attrs) {
     Item.call(this, attrs, table);
@@ -98,8 +89,6 @@ internals.compileModel = (name, schema) => {
   Model.tableName = _.bind(table.tableName, table);
 
   table.itemFactory = Model;
-
-  Model.log = log;
 
   // hooks
   Model.after = _.bind(table.after, table);

--- a/lib/table.js
+++ b/lib/table.js
@@ -12,12 +12,11 @@ const expressions = require('./expressions');
 
 const internals = {};
 
-const Table = module.exports = function (name, schema, serializer, docClient, logger) {
+const Table = module.exports = function (name, schema, serializer, docClient) {
   this.config = { name: name };
   this.schema = schema;
   this.serializer = serializer;
   this.docClient = docClient;
-  this.log = logger;
 
   this._before = new EventEmitter();
   this.before = this._before.on.bind(this._before);
@@ -58,17 +57,10 @@ Table.prototype.sendRequest = function (method, params, callback) {
     driver = self.docClient.service;
   }
 
-  const startTime = Date.now();
-
-  self.log.info({ params: params }, 'dynogels %s request', method.toUpperCase());
   driver[method].call(driver, params, (err, data) => {
-    const elapsed = Date.now() - startTime;
-
     if (err) {
-      self.log.warn({ err: err }, 'dynogels %s error', method.toUpperCase());
       return callback(err);
     } else {
-      self.log.info({ data: data }, 'dynogels %s response - %sms', method.toUpperCase(), elapsed);
       return callback(null, data);
     }
   });
@@ -734,7 +726,6 @@ internals.syncIndexes = (table, callback) => {
       const newIndexWriteThroughput = _.ceil(currentWriteThroughput * 1.5);
       params.writeCapacity = params.writeCapacity || newIndexWriteThroughput;
 
-      table.log.info('adding index %s to table %s', params.name, table.tableName());
 
       const updateParams = {
         TableName: table.tableName(),

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "async": "^2.0.0",
     "aws-sdk": "^2.4.8",
-    "bunyan": "^1.8.1",
     "joi": "^9.2.0",
     "lodash": "^4.13.1",
     "uuid": "^3.0.0"
@@ -42,7 +41,7 @@
     "eslint-plugin-import": "^1.11.1",
     "istanbul": "^0.4.4",
     "jscoverage": "^0.6.0",
-    "mocha": "^2.5.3",
+    "mocha": "3.2.0",
     "sinon": "^1.17.4"
   }
 }

--- a/test/item-test.js
+++ b/test/item-test.js
@@ -25,7 +25,7 @@ describe('item', () => {
 
     const schema = new Schema(config);
 
-    table = new Table('mockTable', schema, serializer, helper.mockDocClient(), helper.testLogger());
+    table = new Table('mockTable', schema, serializer, helper.mockDocClient());
   });
 
   it('JSON.stringify should only serialize attrs', () => {

--- a/test/parallel-test.js
+++ b/test/parallel-test.js
@@ -26,7 +26,7 @@ describe('ParallelScan', () => {
 
     const schema = new Schema(config);
 
-    table = new Table('mockTable', schema, serializer, helper.mockDynamoDB(), helper.testLogger());
+    table = new Table('mockTable', schema, serializer, helper.mockDynamoDB());
   });
 
   it('should return error', done => {

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -22,7 +22,6 @@ describe('Query', () => {
     table = helper.mockTable();
     table.config = { name: 'accounts' };
     table.docClient = helper.mockDocClient();
-    table.log = helper.testLogger();
   });
 
   describe('#exec', () => {
@@ -58,7 +57,7 @@ describe('Query', () => {
       };
 
       const s = new Schema(config);
-      const t = new Table('accounts', s, Serializer, helper.mockDocClient(), helper.testLogger());
+      const t = new Table('accounts', s, Serializer, helper.mockDocClient());
 
       t.docClient.query.yields(new Error('Fail'));
 
@@ -81,7 +80,7 @@ describe('Query', () => {
 
       const s = new Schema(config);
 
-      const t = new Table('accounts', s, Serializer, helper.mockDocClient(), helper.testLogger());
+      const t = new Table('accounts', s, Serializer, helper.mockDocClient());
 
       t.docClient.query.yields(new Error('Fail'));
 
@@ -109,7 +108,7 @@ describe('Query', () => {
 
       const s = new Schema(config);
 
-      const t = new Table('accounts', s, Serializer, helper.mockDocClient(), helper.testLogger());
+      const t = new Table('accounts', s, Serializer, helper.mockDocClient());
 
       const err = new Error('RetryableException');
       err.retryable = true;

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -20,13 +20,11 @@ describe('table', () => {
   let serializer;
   let docClient;
   let dynamodb;
-  let logger;
 
   beforeEach(() => {
     serializer = helper.mockSerializer();
     docClient = helper.mockDocClient();
     dynamodb = docClient.service;
-    logger = helper.testLogger();
   });
 
   describe('#get', () => {
@@ -37,7 +35,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -67,7 +65,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -99,7 +97,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -130,7 +128,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -166,7 +164,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const request = {
         TableName: 'accounts_2014',
@@ -195,7 +193,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       docClient.get.yields(new Error('Fail'));
 
@@ -220,7 +218,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -256,7 +254,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -294,7 +292,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const numberSet = sinon.match(value => {
         const s = docClient.createSet([1, 2, 3]);
@@ -342,7 +340,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -376,7 +374,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -410,7 +408,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -445,7 +443,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -477,7 +475,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -511,7 +509,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -539,7 +537,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       table.create({ email: 'test@test.com', name: [1, 2, 3] }, (err, account) => {
         expect(err).to.exist;
@@ -562,7 +560,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -598,7 +596,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -633,7 +631,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -668,7 +666,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -713,7 +711,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('users', s, realSerializer, docClient, logger);
+      table = new Table('users', s, realSerializer, docClient);
 
       const request = {
         TableName: 'users',
@@ -750,7 +748,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -797,7 +795,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -851,7 +849,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -890,7 +888,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       docClient.update.yields(new Error('Fail'));
 
@@ -914,7 +912,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const item = { name: 'Dr. Who', birthday: undefined };
 
@@ -939,7 +937,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, serializer, docClient, logger);
+      table = new Table('accounts', s, serializer, docClient);
 
       table.query('Bob').should.be.instanceof(Query);
     });
@@ -958,7 +956,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, serializer, docClient, logger);
+      table = new Table('accounts', s, serializer, docClient);
 
       table.scan().should.be.instanceof(Scan);
     });
@@ -977,7 +975,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, serializer, docClient, logger);
+      table = new Table('accounts', s, serializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -1010,7 +1008,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('users', s, serializer, docClient, logger);
+      table = new Table('users', s, serializer, docClient);
 
       const request = {
         TableName: 'users',
@@ -1044,7 +1042,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, serializer, docClient, logger);
+      table = new Table('accounts', s, serializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -1078,7 +1076,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, serializer, docClient, logger);
+      table = new Table('accounts', s, serializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -1121,7 +1119,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, serializer, docClient, logger);
+      table = new Table('accounts', s, serializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -1166,7 +1164,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, serializer, docClient, logger);
+      table = new Table('accounts', s, serializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -1211,7 +1209,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, serializer, docClient, logger);
+      table = new Table('accounts', s, serializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -1248,7 +1246,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -1277,7 +1275,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, realSerializer, docClient, logger);
+      table = new Table('accounts', s, realSerializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -1310,7 +1308,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, serializer, docClient, logger);
+      table = new Table('accounts', s, serializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -1344,7 +1342,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, serializer, docClient, logger);
+      table = new Table('accounts', s, serializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -1379,7 +1377,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, serializer, docClient, logger);
+      table = new Table('accounts', s, serializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -1425,7 +1423,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, serializer, docClient, logger);
+      table = new Table('accounts', s, serializer, docClient);
 
       const request = {
         TableName: 'accounts',
@@ -1478,7 +1476,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('gameScores', s, serializer, docClient, logger);
+      table = new Table('gameScores', s, serializer, docClient);
 
       const request = {
         TableName: 'gameScores',
@@ -1538,7 +1536,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('gameScores', s, serializer, docClient, logger);
+      table = new Table('gameScores', s, serializer, docClient);
 
       const request = {
         TableName: 'gameScores',
@@ -1590,7 +1588,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, serializer, docClient, logger);
+      table = new Table('accounts', s, serializer, docClient);
 
       const request = {
         TableName: 'accounts'
@@ -1618,7 +1616,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, serializer, docClient, logger);
+      table = new Table('accounts', s, serializer, docClient);
     });
 
     it('should make update table request', done => {
@@ -1663,7 +1661,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, serializer, docClient, logger);
+      table = new Table('accounts', s, serializer, docClient);
     });
 
     it('should make delete table request', done => {
@@ -1705,7 +1703,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, serializer, docClient, logger);
+      table = new Table('accounts', s, serializer, docClient);
 
       table.tableName().should.eql('accounts');
     });
@@ -1722,7 +1720,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, serializer, docClient, logger);
+      table = new Table('accounts', s, serializer, docClient);
 
       table.tableName().should.eql('accounts-2014-03');
     });
@@ -1744,7 +1742,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, serializer, docClient, logger);
+      table = new Table('accounts', s, serializer, docClient);
 
       table.tableName().should.eql(`accounts_${dateString}`);
     });
@@ -1764,7 +1762,7 @@ describe('table', () => {
 
         const s = new Schema(config);
 
-        table = new Table('accounts', s, serializer, docClient, logger);
+        table = new Table('accounts', s, serializer, docClient);
 
         const item = { email: 'test@test.com', name: 'Tim Test', age: 23 };
         docClient.put.yields(null, {});
@@ -1806,7 +1804,7 @@ describe('table', () => {
 
         const s = new Schema(config);
 
-        table = new Table('accounts', s, serializer, docClient, logger);
+        table = new Table('accounts', s, serializer, docClient);
 
         table.before('create', (data, next) => next(new Error('fail')));
 
@@ -1830,7 +1828,7 @@ describe('table', () => {
 
         const s = new Schema(config);
 
-        table = new Table('accounts', s, serializer, docClient, logger);
+        table = new Table('accounts', s, serializer, docClient);
 
         const item = { email: 'test@test.com', name: 'Tim Test', age: 23 };
         docClient.put.yields(null, {});
@@ -1860,7 +1858,7 @@ describe('table', () => {
 
         const s = new Schema(config);
 
-        table = new Table('accounts', s, serializer, docClient, logger);
+        table = new Table('accounts', s, serializer, docClient);
 
         const item = { email: 'test@test.com', name: 'Tim Test', age: 23 };
         docClient.update.yields(null, {});
@@ -1901,7 +1899,7 @@ describe('table', () => {
 
         const s = new Schema(config);
 
-        table = new Table('accounts', s, serializer, docClient, logger);
+        table = new Table('accounts', s, serializer, docClient);
 
         table.before('update', (data, next) => next(new Error('fail')));
 
@@ -1925,7 +1923,7 @@ describe('table', () => {
 
         const s = new Schema(config);
 
-        table = new Table('accounts', s, serializer, docClient, logger);
+        table = new Table('accounts', s, serializer, docClient);
 
         const item = { email: 'test@test.com', name: 'Tim Test', age: 23 };
         docClient.update.yields(null, {});
@@ -1956,7 +1954,7 @@ describe('table', () => {
 
       const s = new Schema(config);
 
-      table = new Table('accounts', s, serializer, docClient, logger);
+      table = new Table('accounts', s, serializer, docClient);
 
       docClient.delete.yields(null, {});
       serializer.buildKey.returns({});

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -4,7 +4,6 @@ const sinon = require('sinon');
 const AWS = require('aws-sdk');
 const Table = require('../lib/table');
 const _ = require('lodash');
-const bunyan = require('bunyan');
 
 exports.mockDynamoDB = () => {
   const opts = { endpoint: 'http://dynamodb-local:8000', apiVersion: '2012-08-10' };
@@ -88,9 +87,3 @@ exports.fakeUUID = () => {
 };
 
 exports.randomName = prefix => `${prefix}_${Date.now()}.${_.random(1000)}`;
-
-exports.testLogger = () => bunyan.createLogger({
-  name: 'dynogels-tests',
-  serializers: { err: bunyan.stdSerializers.err },
-  level: bunyan.FATAL
-});


### PR DESCRIPTION
Proposing this as one approach to fix #65. This is a breaking semver major change but this is what I prefer as I prefer logging to only happen in application code, not in library code, and in particular bunyan's use of native modules that are incompatible between node v4 and node v6 is really annoying. I'm proposing just remove logging entirely, the other options include:

- Allow clients to plug in a logger instance
  - Problem here is each logging module tends to be API incompatible (bunyan API is not the same as the winston API nor the bole API, for example)
- Allow clients to plug in a logging function, then adapt the arguments to their logger as necessary
- Emit loggable events instead such as `info`, `error`, `warn`, etc
