### PR TITLE
Improves doc for query methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,12 @@ BlogPost
   .where('title').null()
   .exec();
 
+// attribute exists
+BlogPost
+  .query('werner@example.com')
+  .where('title').exists()
+  .exec();
+
 BlogPost
   .query('werner@example.com')
   .where('title').beginsWith('Expanding')

--- a/README.md
+++ b/README.md
@@ -674,6 +674,12 @@ BlogPost
   .where('title').gte('Expanding')
   .exec();
 
+// attribute doesn't exist
+BlogPost
+  .query('werner@example.com')
+  .where('title').null()
+  .exec();
+
 BlogPost
   .query('werner@example.com')
   .where('title').beginsWith('Expanding')


### PR DESCRIPTION
Query API is different from that of Scan. Especially `notNull()` of scan is `exists()` in query API.

This is not documented and causes confusion. This addition prevents that.
