### PR TITLE
allow specifying validation options in define() to pass through to Joi

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,23 @@ var BlogPost = dynogels.define('BlogPost', {
 });
 ```
 
+You can pass through validation options to Joi like so:
+
+```js
+var BlogPost = dynogels.define('BlogPost', {
+  hashKey : 'email',
+  rangeKey : 'title',
+  schema : {
+    email   : Joi.string().email(),
+    title   : Joi.string()
+  },
+  validation: {
+    // allow properties not defined in the schema
+    allowUnknown: true
+  }
+});
+```
+
 ### Create Tables for all defined models
 
 ```js

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -29,6 +29,19 @@ internals.configSchema = Joi.object().keys({
     info: Joi.func(),
     warn: Joi.func(),
   }).optional().unknown(),
+
+  // based on Joi internals
+  validation: {
+    abortEarly: Joi.boolean(),
+    convert: Joi.boolean(),
+    allowUnknown: Joi.boolean(),
+    skipFunctions: Joi.boolean(),
+    stripUnknown: Joi.boolean(),
+    language: Joi.object(),
+    presence: Joi.string().allow('optional', 'required', 'forbidden', 'ignore'),
+    strip: Joi.boolean(),
+    noDefaults: Joi.boolean()
+  }
 }).required();
 
 internals.wireType = key => {
@@ -81,6 +94,7 @@ internals.parseDynamoTypes = data => {
 const Schema = module.exports = function (config) {
   this.secondaryIndexes = {};
   this.globalIndexes = {};
+  this.validationOptions = config.validation;
 
   const context = { hashKey: config.hashKey };
 
@@ -167,6 +181,9 @@ Schema.types.timeUUID = () => Joi.string().guid().default(() => nodeUUID.v1(), '
 
 Schema.prototype.validate = function (params, options) {
   options = options || {};
+  if (this.validationOptions) {
+    _.extend(options, this.validationOptions);
+  }
 
   return Joi.validate(params, this._modelSchema, options);
 };

--- a/test/schema-test.js
+++ b/test/schema-test.js
@@ -409,6 +409,21 @@ describe('schema', () => {
       expect(s.validate({ created: new Date() }).error).to.be.null;
       expect(s.validate({ created: Date.now() }).error).to.be.null;
     });
+
+    it('should pass through validation options', () => {
+      const config = {
+        hashKey: 'name',
+        schema: {
+          name: Joi.string()
+        },
+        validation: {
+          allowUnknown: true
+        }
+      };
+
+      const s = new Schema(config);
+      expect(s.validate({ name: 'foo', age: 1 }).error).to.be.null;
+    });
   });
 
   describe('#applyDefaults', () => {


### PR DESCRIPTION
added a test and example in README (admittedly targeting my primary use case for this feature)