### PR TITLE
Adding .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+coverage


### PR DESCRIPTION
Running `npm run ci` twice will fail without this because `eslint` will check the `coverage` folder