### PR TITLE
Better lifecycle hooks

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+coverage

--- a/examples/hooks.js
+++ b/examples/hooks.js
@@ -21,24 +21,27 @@ Account.before('create', (data, next) => {
     data.name = 'Foo Bar';
   }
 
-  return next(null, data);
+  next(null, data);
 });
 
 Account.before('update', (data, next) => {
   data.age = 45;
-  return next(null, data);
+  next(null, data);
 });
 
-Account.after('create', item => {
+Account.after('create', (item, next) => {
   console.log('Account created', item.get());
+  next(null, item);
 });
 
-Account.after('update', item => {
+Account.after('update', (item, next) => {
   console.log('Account updated', item.get());
+  next(null, item);
 });
 
-Account.after('destroy', item => {
+Account.after('destroy', (item, next) => {
   console.log('Account destroyed', item.get());
+  next(null, item);
 });
 
 dynogels.createTables(err => {

--- a/lib/table.js
+++ b/lib/table.js
@@ -111,8 +111,8 @@ Table.prototype.get = function (hashKey, rangeKey, options, callback) {
   });
 };
 
-internals.callBeforeHooks = (table, name, startFun, callback) => {
-  const listeners = table._before.listeners(name);
+internals.callHooks = (table, stage, name, startFun, callback) => {
+  const listeners = table[stage].listeners(name);
 
   return async.waterfall([startFun].concat(listeners), callback);
 };
@@ -138,7 +138,7 @@ Table.prototype.create = function (item, options, callback) {
 internals.createItem = (table, item, options, callback) => {
   const self = table;
 
-  const start = callback => {
+  internals.callHooks(self, '_before', 'create', callback => {
     const data = self.schema.applyDefaults(item);
 
     const paramName = _.isString(self.schema.createdAt) ? self.schema.createdAt : 'createdAt';
@@ -148,9 +148,7 @@ internals.createItem = (table, item, options, callback) => {
     }
 
     return callback(null, data);
-  };
-
-  internals.callBeforeHooks(self, 'create', start, (err, data) => {
+  }, (err, data) => {
     if (err) {
       return callback(err);
     }
@@ -192,10 +190,9 @@ internals.createItem = (table, item, options, callback) => {
         return callback(err);
       }
 
-      const item = self.initItem(attrs);
-      self._after.emit('create', item);
-
-      return callback(null, item);
+      internals.callHooks(self, '_after', 'create', callback => {
+        callback(null, self.initItem(attrs));
+      }, callback);
     });
   });
 };
@@ -303,7 +300,7 @@ Table.prototype.update = function (item, options, callback) {
     }));
   }
 
-  const start = callback => {
+  internals.callHooks(self, '_before', 'update', callback => {
     const paramName = _.isString(self.schema.updatedAt) ? self.schema.updatedAt : 'updatedAt';
 
     if (self.schema.timestamps && self.schema.updatedAt !== false && !_.has(item, paramName)) {
@@ -311,9 +308,7 @@ Table.prototype.update = function (item, options, callback) {
     }
 
     return callback(null, item);
-  };
-
-  internals.callBeforeHooks(self, 'update', start, (err, data) => {
+  }, (err, data) => {
     if (err) {
       return callback(err);
     }
@@ -353,13 +348,10 @@ Table.prototype.update = function (item, options, callback) {
         return callback(err);
       }
 
-      let result = null;
-      if (data.Attributes) {
-        result = self.initItem(self.serializer.deserializeItem(data.Attributes));
-      }
-
-      self._after.emit('update', result);
-      return callback(null, result);
+      internals.callHooks(self, '_after', 'update', callback => {
+        callback(null, self.initItem(self.serializer.deserializeItem(
+          data.Attributes || params.Key)));
+      }, callback);
     });
   });
 };
@@ -446,13 +438,10 @@ Table.prototype.destroy = function (hashKey, rangeKey, options, callback) {
       return callback(err);
     }
 
-    let item = null;
-    if (data.Attributes) {
-      item = self.initItem(self.serializer.deserializeItem(data.Attributes));
-    }
-
-    self._after.emit('destroy', item);
-    return callback(null, item);
+    internals.callHooks(self, '_after', 'destroy', callback => {
+      callback(null, self.initItem(self.serializer.deserializeItem(
+        data.Attributes || params.Key)));
+    }, callback);
   });
 };
 

--- a/test/item-test.js
+++ b/test/item-test.js
@@ -90,7 +90,7 @@ describe('item', () => {
 
       item.update((err, data) => {
         expect(err).to.not.exist;
-        expect(data).to.not.exist;
+        expect(data.get()).to.eql({ num: 1 });
 
         return done();
       });


### PR DESCRIPTION
* after hooks behave the same as before hooks, with chain of middleware
* added key as the item when it would otherwise be null

The motivation is to be able to perform some kind of operation after a successful change to DynamoDB. For example, updating elasticsearch. This makes it possible to wait for that secondary operation to complete.

Passing in the key to the hook handlers (at minimum) makes it possible to identify the affected item at the very least.