### PR TITLE
Validate method

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Dynogels is a [DynamoDB][5] data mapper for [node.js][1]. This project has been 
 ## Features
 * Simplified data modeling and mapping to DynamoDB types
 * Advanced chainable apis for [query](#query) and [scan](#scan) operations
-* Data validation
+* [Data validation](#validation)
 * [Autogenerating UUIDs](#uuid)
 * [Global Secondary Indexes](#global-indexes)
 * [Local Secondary Indexes](#local-secondary-indexes)
@@ -188,6 +188,28 @@ var Tweet = dynogels.define('Tweet', {
     content : Joi.string(),
   }
 });
+```
+
+#### Data Validation
+Dynogels automatically validates the model against the schema before attempting to save it, but you can also call the `validate` method to validate an object before saving it. This can be helpful for a handler to validate input.
+
+```js
+var Tweet = dynogels.define('Tweet', {
+  hashKey : 'TweetID',
+  timestamps : true,
+  schema : {
+    TweetID : dynogels.types.uuid(),
+    content : Joi.string(),
+  }
+});
+
+const tweet = new Tweet({ content: 123 })
+const fail_result = Tweet.validate(tweet)
+console.log(fail_result.error.name) // ValidationError
+
+tweet.set('content', 'This is the content')
+const pass_result = Tweet.validate(tweet)
+console.log(pass_result.error) // null
 ```
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Dynogels is a [DynamoDB][5] data mapper for [node.js][1]. This project has been 
 ## Features
 * Simplified data modeling and mapping to DynamoDB types
 * Advanced chainable apis for [query](#query) and [scan](#scan) operations
-* [Data validation](#validation)
+* [Data validation](#data-validation)
 * [Autogenerating UUIDs](#uuid)
 * [Global Secondary Indexes](#global-indexes)
 * [Local Secondary Indexes](#local-secondary-indexes)

--- a/lib/index.js
+++ b/lib/index.js
@@ -81,6 +81,7 @@ internals.compileModel = (name, schema, log) => {
   Model.query = _.bind(table.query, table);
   Model.scan = _.bind(table.scan, table);
   Model.parallelScan = _.bind(table.parallelScan, table);
+  Model.validate = _.bind(table.validate, table);
 
   Model.getItems = batch(table, serializer).getItems;
   Model.batchGetItems = batch(table, serializer).getItems;

--- a/lib/table.js
+++ b/lib/table.js
@@ -284,6 +284,10 @@ internals.validateItemFragment = (item, schema) => {
   return result;
 };
 
+Table.prototype.validate = function (item) {
+  return this.schema.validate(item.attrs);
+};
+
 Table.prototype.update = function (item, options, callback) {
   const self = this;
 

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -57,6 +57,12 @@ describe('dynogels', () => {
       const acc = new Account({ name: 'Test Acc' });
       acc.table.should.be.instanceof(Table);
     });
+
+    it('should have validate method', () => {
+      const Account = dynogels.define('Account', { hashKey: 'id' });
+      expect(Account.validate).to.exist;
+      expect(Account.validate).to.be.a('function');
+    });
   });
 
   describe('#models', () => {

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1104,7 +1104,7 @@ describe('table', () => {
       serializer.buildKey.returns(request.Key);
       serializer.deserializeItem.withArgs(returnedAttributes).returns(
         { email: 'test@test.com', name: 'Foo Bar'
-      });
+        });
 
       table.destroy('test@test.com', { ReturnValues: 'ALL_OLD' }, (err, item) => {
         serializer.buildKey.calledWith('test@test.com', null, s).should.be.true;
@@ -1149,7 +1149,7 @@ describe('table', () => {
       serializer.buildKey.returns(request.Key);
       serializer.deserializeItem.withArgs(returnedAttributes).returns(
         { email: 'test@test.com', name: 'Foo Bar'
-      });
+        });
 
       table.destroy('test@test.com', 'Foo Bar', (err, item) => {
         serializer.buildKey.calledWith('test@test.com', 'Foo Bar', s).should.be.true;
@@ -1195,7 +1195,7 @@ describe('table', () => {
       serializer.buildKey.returns(request.Key);
       serializer.deserializeItem.withArgs(returnedAttributes).returns(
         { email: 'test@test.com', name: 'Foo Bar'
-      });
+        });
 
       table.destroy('test@test.com', 'Foo Bar', { ReturnValues: 'ALL_OLD' }, (err, item) => {
         serializer.buildKey.calledWith('test@test.com', 'Foo Bar', s).should.be.true;
@@ -1971,7 +1971,85 @@ describe('table', () => {
 
       table.after('destroy', () => done());
 
-      table.destroy('test@test.com', () => {});
+      table.destroy('test@test.com', () => { });
+    });
+  });
+
+  describe('#validate', () => {
+    const helper = (config, attrs) => {
+      const s = new Schema(config);
+
+      table = new Table('accounts', s, serializer, docClient, logger);
+      const item = new Item(attrs, table);
+      return table.validate(item);
+    };
+
+    it('should succeed for empty item when nothing is required', () => {
+      const config = {
+        hashKey: 'email',
+        schema: {
+          email: Joi.string()
+        }
+      };
+      const attrs = {};
+
+      const result = helper(config, attrs);
+      expect(result.error).to.be.null;
+    });
+
+    it('should succeed with required items', () => {
+      const config = {
+        hashKey: 'email',
+        schema: {
+          email: Joi.string().required()
+        }
+      };
+      const attrs = { email: 'test@email.com' };
+
+      const result = helper(config, attrs);
+      expect(result.error).to.be.null;
+    });
+
+    it('should fail when missing required string field', () => {
+      const config = {
+        hashKey: 'email',
+        schema: {
+          email: Joi.string().required()
+        }
+      };
+      const attrs = {};
+
+      const result = helper(config, attrs);
+      expect(result.error).to.not.be.null;
+      expect(result.error.name).to.eql('ValidationError');
+    });
+
+    it('should fail when giving numbers to string types', () => {
+      const config = {
+        hashKey: 'email',
+        schema: {
+          email: Joi.string()
+        }
+      };
+      const attrs = { email: 123 };
+
+      const result = helper(config, attrs);
+      expect(result.error).to.not.be.null;
+      expect(result.error.name).to.eql('ValidationError');
+    });
+
+    it('should fail when giving strings to number types', () => {
+      const config = {
+        hashKey: 'phone',
+        schema: {
+          email: Joi.number()
+        }
+      };
+      const attrs = { phone: 123 };
+
+      const result = helper(config, attrs);
+      expect(result.error).to.not.be.null;
+      expect(result.error.name).to.eql('ValidationError');
     });
   });
 });


### PR DESCRIPTION
I exposed a `validate` method on the dynogels model to solve #24.  So now you can use the model to validate an instance like below.  I included some tests and documentation updates.  My tests don't cover many permutations so let me know if there is something that doesn't validate through this method.

```js
const Tweet = dynogels.define({
....
})
const tweet = new Tweet({.....})
Tweet.validate(tweet) // returns { error, value }
```