### PR TITLE
Support updating attributes that throw custom errors

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -234,7 +234,7 @@ internals.validateItemFragment = (item, schema) => {
   const result = {};
   const error = {};
 
-  // get the list of attributes to remove
+  // get the list of attributes to remove (delete) in an update
   const removeAttributes = _.pickBy(item, _.isNull);
 
   // get the list of attributes whose value is an object
@@ -271,10 +271,15 @@ internals.validateItemFragment = (item, schema) => {
   );
 
   if (updateValidation.error) {
-    const errors = _.omitBy(
-      updateValidation.error.details,
-      e => _.isEqual(e.type, 'any.required')
-    );
+    let errors = [];
+    if (!updateValidation.error.details) {
+      errors = [updateValidation.error];
+    } else {
+      errors = _.omitBy(
+        updateValidation.error.details,
+        e => _.isEqual(e.type, 'any.required')
+      );
+    }
     if (!_.isEmpty(errors)) {
       error.update = errors;
       result.error = error;
@@ -301,10 +306,7 @@ Table.prototype.update = function (item, options, callback) {
 
   const schemaValidation = internals.validateItemFragment(item, self.schema);
   if (schemaValidation.error) {
-    return callback(_.assign(new Error(`Schema validation error while updating item in table ${self.tableName()}: ${JSON.stringify(schemaValidation.error)}`), {
-      name: 'DynogelsUpdateError',
-      detail: schemaValidation.error
-    }));
+    return callback(schemaValidation.error);
   }
 
   const start = callback => {

--- a/test/integration/integration-test.js
+++ b/test/integration/integration-test.js
@@ -536,14 +536,15 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should fail with custom error', done => {
+    it('should fail on update with custom error', done => {
       User.update({
         id: '123456789',
         custom: 'forbidden'
       }, (err, acc) => {
         expect(err).to.exist;
+        expect(err.update).to.exist;
         expect(acc).to.not.exist;
-        expect(err).to.match(/Custom field is prohibited/);
+        expect(err.update).to.match(/Custom field is prohibited/);
         done();
       });
     });

--- a/test/integration/integration-test.js
+++ b/test/integration/integration-test.js
@@ -12,6 +12,7 @@ const Joi = require('joi');
 chai.should();
 
 let User;
+let CustomUser;
 let Tweet;
 let Movie;
 let DynamicKeyModel;
@@ -87,13 +88,21 @@ describe('Dynogels Integration Tests', function () {
         roles: dynogels.types.stringSet().default(['user']),
         acceptedTerms: Joi.boolean().default(false),
         things: Joi.array(),
-        custom: Joi.any().forbidden().error(new Error('Custom field is prohibited')),
         settings: {
           nickname: Joi.string(),
           notify: Joi.boolean().default(true),
           version: Joi.number()
         }
 
+      }
+    });
+
+    CustomUser = dynogels.define('dynogels-int-test-customuser', {
+      hashKey: 'id',
+      schema: {
+        id: Joi.string().default(() => uuid.v4(), 'uuid'),
+        custom: Joi.any().forbidden().error(new Error('Custom field is prohibited')),
+        email: Joi.string().required().error(new Error('Email is required!!!'))
       }
     });
 
@@ -263,7 +272,7 @@ describe('Dynogels Integration Tests', function () {
 
     it('should return custom errors specified in the schema', done => {
       const item = { id: '123456789', email: 'newemail', custom: 'forbidden' };
-      User.create(item, (err, acc) => {
+      CustomUser.create(item, (err, acc) => {
         expect(err).to.exist;
         expect(acc).to.not.exist;
         expect(err).to.match(/Custom field is prohibited/);
@@ -537,16 +546,47 @@ describe('Dynogels Integration Tests', function () {
     });
 
     it('should fail on update with custom error', done => {
-      User.update({
-        id: '123456789',
-        custom: 'forbidden'
-      }, (err, acc) => {
-        expect(err).to.exist;
-        expect(err.update).to.exist;
-        expect(acc).to.not.exist;
-        expect(err.update).to.match(/Custom field is prohibited/);
-        done();
-      });
+      CustomUser.create(
+        {
+          id: '0987654321',
+          email: 'update@test.com'
+        },
+        (err, acc) => {
+          expect(err).to.not.exist;
+          expect(acc).to.exist;
+          CustomUser.update({
+            id: acc.get('id'),
+            custom: 'forbidden'
+          }, (err, acc) => {
+            expect(err).to.exist;
+            expect(err.update).to.exist;
+            expect(acc).to.not.exist;
+            expect(err.update).to.match(/Custom field is prohibited/);
+            done();
+          });
+        });
+    });
+
+    it('should fail when removing a required attribute with a custom error', done => {
+      CustomUser.create(
+        {
+          id: '1234567890',
+          email: 'email@test.com'
+        },
+        (err, acc) => {
+          expect(err).to.not.exist;
+          expect(acc).to.exist;
+          CustomUser.update(
+            { id: acc.get('id'), email: null },
+            (err, acc) => {
+              console.log(err);
+              expect(err).to.exist;
+              expect(err.update).to.exist;
+              expect(acc).to.not.exist;
+              expect(err.update).to.match(/Email is required!!!/);
+              done();
+            });
+        });
     });
   });
 


### PR DESCRIPTION
This now works for updating attributes.  However, if you have an attribute that is `required()` and has a custom `error()` specified in the Joi schema it will fail to update the item but return no error at all.

