### PR TITLE
Update logger documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1143,14 +1143,18 @@ var Event = dynogels.define('Event', {
 ```
 
 ### Logging
-A logger that implements `info` and `warn` methods (e.g [Bunyan](https://www.npmjs.com/package/bunyan) or [Winston](https://www.npmjs.com/package/winston))
-can be provided to either dynogels itself or individual models:
+A [Bunyan](https://www.npmjs.com/package/bunyan) logger instance can be provided to either dynogels itself or individual models.  Dynogels requests are logged at the `info` level. 
+Other loggers that implement `info` and `warn` methods can also be used.  [Winston](https://www.npmjs.com/package/winston))  uses a different parameter signature than bunyan and the log messages are improperly formatted.
 
 ```js
-const logger = require('winston');
-logger.level = 'warn';
+const bunyan = require('bunyan');
+const logger = bunyan.createLogger(
+  {
+    name: 'myApp',
+    level:'info'
+  })
 
-dynogels.log = logger;  // enabled WARN log level on all tables
+dynogels.log = logger;
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1144,13 +1144,13 @@ var Event = dynogels.define('Event', {
 
 ### Logging
 A [Bunyan](https://www.npmjs.com/package/bunyan) logger instance can be provided to either dynogels itself or individual models.  Dynogels requests are logged at the `info` level. 
-Other loggers that implement `info` and `warn` methods can also be used.  [Winston](https://www.npmjs.com/package/winston))  uses a different parameter signature than bunyan and the log messages are improperly formatted.
+Other loggers that implement `info` and `warn` methods can also be used. However, [Winston](https://www.npmjs.com/package/winston) uses a different parameter signature than bunyan so the log messages are improperly formatted when using Winston.
 
 ```js
 const bunyan = require('bunyan');
 const logger = bunyan.createLogger(
   {
-    name: 'myApp',
+    name: 'globalLogger',
     level:'info'
   })
 
@@ -1159,8 +1159,12 @@ dynogels.log = logger;
 
 
 ```js
-const accountLogger = require('winston');
-accountLogger.level = 'info';
+const bunyan = require('bunyan');
+const accountLogger = bunyan.createLogger(
+  {
+    name: 'modelLogger',
+    level:'info'
+  })
 
 var Account = dynogels.define('Account', {
   hashKey: 'email',


### PR DESCRIPTION
This updates the documentation regarding adding a logger to dynogels.  I found that `Winston` did not format log messages correctly because it has a different parameter signature than `Bunyan`.  This answers #121.