### PR TITLE
Remove update validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,9 @@ Use the `overwrite` option to prevent over writing of existing records.
 ### Updating
 
 When updating a model the hash and range key attributes must be given, all
-other attributes are optional
+other attributes are optional.  Schema validation is not possible on partial
+models, so it is possible to update a model to a state that is not consistent
+with the schema.
 
 ```js
 // update the name of the foo@example.com account

--- a/lib/table.js
+++ b/lib/table.js
@@ -230,60 +230,6 @@ internals.updateExpressions = (schema, data, options) => {
   });
 };
 
-internals.validateItemFragment = (item, schema) => {
-  const result = {};
-  const error = {};
-
-  // get the list of attributes to remove
-  const removeAttributes = _.pickBy(item, _.isNull);
-
-  // get the list of attributes whose value is an object
-  const setOperationValues = _.pickBy(item, i => _.isPlainObject(i) && (i.$add || i.$del));
-
-  // get the list of attributes to modify
-  const updateAttributes = _.omit(
-    item,
-    Object.keys(removeAttributes).concat(Object.keys(setOperationValues))
-  );
-
-  // check attribute removals for .required() schema violation
-  const removalValidation = schema.validate(
-    {},
-    { abortEarly: false }
-  );
-
-  if (removalValidation.error) {
-    const errors = _.pickBy(
-      removalValidation.error.details,
-      e => _.isEqual(e.type, 'any.required')
-      && Object.prototype.hasOwnProperty.call(removeAttributes, e.path)
-    );
-    if (!_.isEmpty(errors)) {
-      error.remove = errors;
-      result.error = error;
-    }
-  }
-
-  // check attribute updates match the schema
-  const updateValidation = schema.validate(
-    updateAttributes,
-    { abortEarly: false }
-  );
-
-  if (updateValidation.error) {
-    const errors = _.omitBy(
-      updateValidation.error.details,
-      e => _.isEqual(e.type, 'any.required')
-    );
-    if (!_.isEmpty(errors)) {
-      error.update = errors;
-      result.error = error;
-    }
-  }
-
-  return result;
-};
-
 Table.prototype.validate = function (item) {
   return this.schema.validate(item.attrs);
 };
@@ -298,14 +244,6 @@ Table.prototype.update = function (item, options, callback) {
 
   callback = callback || _.noop;
   options = options || {};
-
-  const schemaValidation = internals.validateItemFragment(item, self.schema);
-  if (schemaValidation.error) {
-    return callback(_.assign(new Error(`Schema validation error while updating item in table ${self.tableName()}: ${JSON.stringify(schemaValidation.error)}`), {
-      name: 'DynogelsUpdateError',
-      detail: schemaValidation.error
-    }));
-  }
 
   const start = callback => {
     const paramName = _.isString(self.schema.updatedAt) ? self.schema.updatedAt : 'updatedAt';

--- a/test/integration/integration-test.js
+++ b/test/integration/integration-test.js
@@ -481,28 +481,6 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should fail to update an attribute not in the schema', (done) => {
-      User.update({
-        id: '123456789',
-        invalidAttribute: 'Invalid Value'
-      }, (err, account) => {
-        expect(err).to.exist;
-        expect(account).to.not.exist;
-        return done();
-      });
-    });
-
-    it('should fail to remove a required attribute', (done) => {
-      User.update({
-        id: '123456789',
-        email: null
-      }, (err, account) => {
-        expect(err).to.exist;
-        expect(account).to.not.exist;
-        done();
-      });
-    });
-
     it('should successfully remove an optional attribute', (done) => {
       User.update({
         id: '123456789',
@@ -514,17 +492,6 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should fail for attribute mismatch to schema type', (done) => {
-      User.update({
-        id: '123456789',
-        name: 1
-      }, (err, account) => {
-        expect(err).to.exist;
-        expect(account).to.not.exist;
-        done();
-      });
-    });
-
     it('should fail to use $add for an invalid attribute', (done) => {
       User.update({
         id: '123456789',
@@ -532,18 +499,6 @@ describe('Dynogels Integration Tests', function () {
       }, (err, acc) => {
         expect(err).to.exist;
         expect(acc).to.not.exist;
-        done();
-      });
-    });
-
-    it('should fail with custom error', done => {
-      User.update({
-        id: '123456789',
-        custom: 'forbidden'
-      }, (err, acc) => {
-        expect(err).to.exist;
-        expect(acc).to.not.exist;
-        expect(err).to.match(/Custom field is prohibited/);
         done();
       });
     });


### PR DESCRIPTION
This removes the attempt to partially validate the Joi schema on `update` requests.  Joi does not provide the functionality to do this and attempting to write a partial schema validation function was problematic and not within the scope of dynogels.  There was an issue asking about this in Joi (hapijs/joi#556) but they didn't want to implement this type of functionality either.