### PR TITLE
Adds support for server side encryption setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,12 @@ When creating tables you can pass specific throughput settings or stream specifi
 dynogels.createTables({
   'BlogPost': {readCapacity: 5, writeCapacity: 10},
   'Account': {
-    readCapacity: 20, 
-    writeCapacity: 4, 
-    streamSpecification: { 
-      streamEnabled: true, 
-      streamViewType: 'NEW_IMAGE' 
+    readCapacity: 20,
+    writeCapacity: 4,
+    encryption: true,
+    streamSpecification: {
+      streamEnabled: true,
+      streamViewType: 'NEW_IMAGE'
     }
   }
 }, function(err) {
@@ -630,7 +631,7 @@ BlogPost
   .query('werner@example.com')
   .where('title').beginsWith('Expanding')
   .exec(callback);
-  
+
 // return only the count of documents that begin with the title Expanding
 BlogPost
   .query('werner@example.com')
@@ -1143,7 +1144,7 @@ var Event = dynogels.define('Event', {
 ```
 
 ### Logging
-A [Bunyan](https://www.npmjs.com/package/bunyan) logger instance can be provided to either dynogels itself or individual models.  Dynogels requests are logged at the `info` level. 
+A [Bunyan](https://www.npmjs.com/package/bunyan) logger instance can be provided to either dynogels itself or individual models.  Dynogels requests are logged at the `info` level.
 Other loggers that implement `info` and `warn` methods can also be used. However, [Winston](https://www.npmjs.com/package/winston) uses a different parameter signature than bunyan so the log messages are improperly formatted when using Winston.
 
 ```js

--- a/lib/table.js
+++ b/lib/table.js
@@ -615,6 +615,9 @@ Table.prototype.createTable = function (options, callback) {
     ProvisionedThroughput: {
       ReadCapacityUnits: options.readCapacity || 1,
       WriteCapacityUnits: options.writeCapacity || 1
+    },
+    SSESpecification: {
+      Enabled: options.encryption || false,
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "2.5.0",
-    "aws-sdk": "2.131.0",
+    "aws-sdk": "2.191.0",
     "joi": "11.3.4",
     "lodash": "4.17.4",
     "uuid": "3.1.0"


### PR DESCRIPTION
Adds support for SSE on create table. See docs here:
https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/encryption.tutorial.html
https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateTable.html
https://aws.amazon.com/about-aws/whats-new/2018/02/amazon-dynamodb-now-supports-server-side-encryption-at-rest/