### PR TITLE
Add SSESpecification when creating table with `encrypt` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,20 @@ var Account = dynogels.define('Account', {
 });
 ```
 
+You can also enable server-side encryption with `encrypt` that indicate whether server-side encryption is enabled (`true`) or disabled (`false`) on the table.
+
+```js
+var Event = dynogels.define('SecureData', {
+  hashKey : 'name',
+  encrypt: true,
+  schema : {
+    name : Joi.string(),
+    total : Joi.number()
+  },
+
+});
+```
+
 You can override the table name the model will use.
 
 ```js

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -20,6 +20,7 @@ internals.configSchema = Joi.object().keys({
   hashKey: Joi.string().required(),
   rangeKey: Joi.string(),
   tableName: Joi.alternatives().try(Joi.string(), Joi.func()),
+  encrypt: Joi.boolean().default(false),
   indexes: Joi.array().items(internals.secondaryIndexSchema),
   schema: Joi.object(),
   timestamps: Joi.boolean().default(false),
@@ -111,6 +112,7 @@ const Schema = module.exports = function (config) {
     self.timestamps = data.timestamps;
     self.createdAt = data.createdAt;
     self.updatedAt = data.updatedAt;
+    self.encrypt = data.encrypt;
 
     if (data.indexes) {
       self.globalIndexes = _.chain(data.indexes).filter({ type: 'global' }).keyBy('name').value();

--- a/lib/table.js
+++ b/lib/table.js
@@ -618,6 +618,12 @@ Table.prototype.createTable = function (options, callback) {
     }
   };
 
+  if (self.schema.encrypt === true) {
+    params.SSESpecification = {
+      Enabled: true
+    };
+  }
+
   if (localSecondaryIndexes.length >= 1) {
     params.LocalSecondaryIndexes = localSecondaryIndexes;
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "2.5.0",
-    "aws-sdk": "2.131.0",
+    "aws-sdk": "2.298.0",
     "lodash": "4.17.4",
     "uuid": "3.1.0"
   },

--- a/test/schema-test.js
+++ b/test/schema-test.js
@@ -53,6 +53,25 @@ describe('schema', () => {
       s.tableName.should.equal(func);
     });
 
+    it('should add encrypt with default value to schema', () => {
+      const config = {
+        hashKey: 'id'
+      };
+
+      const s = new Schema(config);
+      s.encrypt.should.be.false;
+    });
+
+    it('should add encrypt to schema', () => {
+      const config = {
+        hashKey: 'id',
+        encrypt: true
+      };
+
+      const s = new Schema(config);
+      s.encrypt.should.be.true;
+    });
+
     it('should add timestamps to schema', () => {
       const config = {
         hashKey: 'id',

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1607,6 +1607,42 @@ describe('table', () => {
         done();
       });
     });
+
+    it('should create table with SSESpecification to true', done => {
+      const config = {
+        hashKey: 'email',
+        encrypt: true,
+        schema: {
+          email: Joi.string(),
+        }
+      };
+
+      const s = new Schema(config);
+
+      table = new Table('accounts', s, serializer, docClient, logger);
+
+      const request = {
+        TableName: 'accounts',
+        AttributeDefinitions: [
+          { AttributeName: 'email', AttributeType: 'S' }
+        ],
+        KeySchema: [
+          { AttributeName: 'email', KeyType: 'HASH' }
+        ],
+        ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
+        SSESpecification: {
+          Enabled: true
+        }
+      };
+
+      dynamodb.createTable.yields(null, {});
+
+      table.createTable({ readCapacity: 5, writeCapacity: 5 }, err => {
+        expect(err).to.be.null;
+        dynamodb.createTable.calledWith(request).should.be.true;
+        done();
+      });
+    });
   });
 
   describe('#describeTable', () => {

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1761,12 +1761,12 @@ describe('table', () => {
         expect(dynamoCreateTableParamsStub.args[0]).to.deep.equal([options]);
         dynamodb.createTable.calledWith(mockCreateTableParamsResult).should.be.true;
         sandbox.verify();
-        sandbox.reset();
+        sandbox.restore();
         done();
       });
     });
 
-    it('should create table with SSESpecification to true', done => {
+    it('should create table with SSESpecification to true', (done) => {
       const config = {
         hashKey: 'email',
         encrypt: true,
@@ -1795,7 +1795,7 @@ describe('table', () => {
 
       dynamodb.createTable.yields(null, {});
 
-      table.createTable({ readCapacity: 5, writeCapacity: 5 }, err => {
+      table.createTable({ readCapacity: 5, writeCapacity: 5 }, (err) => {
         expect(err).to.be.null;
         dynamodb.createTable.calledWith(request).should.be.true;
         done();


### PR DESCRIPTION
This PR adds the possibility to setup a `encrypt` flag to a schema :

+ If not specified, its value is `false`
+ if specified and `true`, then the correct configuration to enable table encryption is added to the creation request of the table
+ if `false`, then nothing is added to the creation request of the table

I know this is somewhat a duplicate of #136 but my branch seems to pass tests correctly (I guess we'll see how it goes)