### PR TITLE
Upgrade eslint; fix some new warnings and disable others

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,10 @@
     "new-cap": [0],
     "no-else-return": [0],
     "consistent-return": [0],
-    "prefer-rest-params": [0]
+    "prefer-rest-params": [0],
+    "object-curly-newline": [ "error", { "multiline": true, "consistent": true } ],
+    "prefer-destructuring": [0],
+    "no-multi-assign": [0],
+    "prefer-spread": [0]
   }
 }

--- a/examples/addItems.js
+++ b/examples/addItems.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const dynogels = require('../index');
-const AWS = dynogels.AWS;
 const Joi = require('joi');
 const async = require('async');
 
+const AWS = dynogels.AWS;
 AWS.config.loadFromPath(`${process.env.HOME}/.ec2/credentials.json`);
 
 const Account = dynogels.define('example-Account', {
@@ -20,7 +20,7 @@ const Account = dynogels.define('example-Account', {
 
 dynogels.createTables({
   'example-Account': { readCapacity: 1, writeCapacity: 10 },
-}, err => {
+}, (err) => {
   if (err) {
     console.log('Error creating tables', err);
     process.exit(1);

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -3,9 +3,9 @@
 const dynogels = require('../index');
 const _ = require('lodash');
 const util = require('util');
-const AWS = dynogels.AWS;
 const Joi = require('joi');
 
+const AWS = dynogels.AWS;
 AWS.config.loadFromPath(`${process.env.HOME}/.ec2/credentials.json`);
 
 const Account = dynogels.define('Foobar', {
@@ -45,7 +45,7 @@ const printScanResults = (err, data) => {
   }
 };
 
-dynogels.createTables(err => {
+dynogels.createTables((err) => {
   if (err) {
     console.log('failed to create table', err);
   }
@@ -56,7 +56,10 @@ dynogels.createTables(err => {
 
   // Create an account
   const params = {
-    email: 'test11@example.com', name: 'test 11', age: 21, scores: [22, 55, 44],
+    email: 'test11@example.com',
+    name: 'test 11',
+    age: 21,
+    scores: [22, 55, 44],
     list: ['a', 'b', 'c', 1, 2, 3],
     settings: { nickname: 'tester' }
   };
@@ -64,7 +67,7 @@ dynogels.createTables(err => {
   Account.create(params, (err, acc) => {
     printAccountInfo(err, acc);
 
-    acc.set({ name: 'Test 11', age: 25 }).update(err => {
+    acc.set({ name: 'Test 11', age: 25 }).update((err) => {
       console.log('account updated', err, acc.get());
     });
   });

--- a/examples/batchGet.js
+++ b/examples/batchGet.js
@@ -3,9 +3,9 @@
 const dynogels = require('../index');
 const async = require('async');
 const _ = require('lodash');
-const AWS = dynogels.AWS;
 const Joi = require('joi');
 
+const AWS = dynogels.AWS;
 AWS.config.loadFromPath(`${process.env.HOME}/.ec2/credentials.json`);
 
 const Account = dynogels.define('example-batch-get-account', {
@@ -29,7 +29,7 @@ const printAccountInfo = (err, acc) => {
   }
 };
 
-const loadSeedData = callback => {
+const loadSeedData = (callback) => {
   callback = callback || _.noop;
 
   async.times(15, (n, next) => {
@@ -41,7 +41,7 @@ const loadSeedData = callback => {
 async.series([
   async.apply(dynogels.createTables.bind(dynogels)),
   loadSeedData
-], err => {
+], (err) => {
   if (err) {
     console.log('error', err);
     process.exit(1);
@@ -49,21 +49,21 @@ async.series([
 
   // Get two accounts at once
   Account.getItems(['test1@example.com', 'test2@example.com'], (err, accounts) => {
-    accounts.forEach(acc => {
+    accounts.forEach((acc) => {
       printAccountInfo(null, acc);
     });
   });
 
   // Same as above but a strongly consistent read is used
   Account.getItems(['test3@example.com', 'test4@example.com'], { ConsistentRead: true }, (err, accounts) => {
-    accounts.forEach(acc => {
+    accounts.forEach((acc) => {
       printAccountInfo(null, acc);
     });
   });
 
   // Get two accounts, but only fetching the age attribute
   Account.getItems(['test5@example.com', 'test6@example.com'], { AttributesToGet: ['age'] }, (err, accounts) => {
-    accounts.forEach(acc => {
+    accounts.forEach((acc) => {
       printAccountInfo(null, acc);
     });
   });

--- a/examples/binary.js
+++ b/examples/binary.js
@@ -2,9 +2,9 @@
 
 const dynogels = require('../index');
 const fs = require('fs');
-const AWS = dynogels.AWS;
 const Joi = require('joi');
 
+const AWS = dynogels.AWS;
 AWS.config.loadFromPath(`${process.env.HOME}/.ec2/credentials.json`);
 
 const BinModel = dynogels.define('example-binary', {
@@ -26,7 +26,7 @@ const printFileInfo = (err, file) => {
   }
 };
 
-dynogels.createTables(err => {
+dynogels.createTables((err) => {
   if (err) {
     console.log('Error creating tables', err);
     process.exit(1);

--- a/examples/conditionalWrites.js
+++ b/examples/conditionalWrites.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const dynogels = require('../index');
-const AWS = dynogels.AWS;
 const Joi = require('joi');
+
+const AWS = dynogels.AWS;
 
 dynogels.dynamoDriver(new AWS.DynamoDB({
   endpoint: 'http://localhost:8000',
@@ -22,7 +23,7 @@ const Account = dynogels.define('example-Account', {
 
 dynogels.createTables({
   'example-Account': { readCapacity: 1, writeCapacity: 10 },
-}, err => {
+}, (err) => {
   if (err) {
     console.log('Error creating tables', err);
     process.exit(1);

--- a/examples/createTable.js
+++ b/examples/createTable.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const dynogels = require('../index');
-const AWS = dynogels.AWS;
 const Joi = require('joi');
 
+const AWS = dynogels.AWS;
 AWS.config.loadFromPath(`${process.env.HOME}/.ec2/credentials.json`);
 
 dynogels.define('example-Account', {
@@ -49,7 +49,7 @@ dynogels.createTables({
       streamViewType: 'NEW_IMAGE'
     }
   }
-}, err => {
+}, (err) => {
   if (err) {
     console.log('Error creating tables', err);
   } else {

--- a/examples/dynamicKeys.js
+++ b/examples/dynamicKeys.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const dynogels = require('../index');
-const AWS = dynogels.AWS;
 const Joi = require('joi');
 const async = require('async');
 const util = require('util');
 const _ = require('lodash');
 
+const AWS = dynogels.AWS;
 AWS.config.loadFromPath(`${process.env.HOME}/.ec2/credentials.json`);
 
 const DynamicModel = dynogels.define('example-dynamic-key', {
@@ -36,7 +36,7 @@ const printResults = (err, resp) => {
 
 dynogels.createTables({
   'example-Account': { readCapacity: 1, writeCapacity: 10 },
-}, err => {
+}, (err) => {
   if (err) {
     console.log('Error creating tables', err);
     process.exit(1);

--- a/examples/dynamicTableName.js
+++ b/examples/dynamicTableName.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const dynogels = require('../index');
-const AWS = dynogels.AWS;
 const Joi = require('joi');
 
+const AWS = dynogels.AWS;
 AWS.config.loadFromPath(`${process.env.HOME}/.ec2/credentials.json`);
 
 const Account = dynogels.define('example-tablename', {
@@ -30,7 +30,7 @@ const printAccountInfo = (err, acc) => {
   }
 };
 
-dynogels.createTables(err => {
+dynogels.createTables((err) => {
   if (err) {
     console.log('Failed to create tables', err);
   } else {

--- a/examples/globalSecondaryIndexes.js
+++ b/examples/globalSecondaryIndexes.js
@@ -3,14 +3,12 @@
 const dynogels = require('../index');
 const _ = require('lodash');
 const util = require('util');
-const AWS = dynogels.AWS;
 const Joi = require('joi');
 const async = require('async');
 
-// AWS.config.loadFromPath(`${process.env.HOME}/.ec2/credentials.json`);
-
 // http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.html
 
+const AWS = dynogels.AWS;
 AWS.config.update({ region: 'us-east-1' });
 
 const GameScore = dynogels.define('example-global-index', {
@@ -49,7 +47,7 @@ const data = [
   { userId: '103', gameTitle: 'Starship X', topScore: 42, wins: 4, losses: 19 },
 ];
 
-const loadSeedData = callback => {
+const loadSeedData = (callback) => {
   callback = callback || _.noop;
 
   async.each(data, (attrs, callback) => {
@@ -60,7 +58,7 @@ const loadSeedData = callback => {
 async.series([
   async.apply(dynogels.createTables.bind(dynogels)),
   loadSeedData
-], err => {
+], (err) => {
   if (err) {
     console.log('error', err);
     process.exit(1);
@@ -68,16 +66,16 @@ async.series([
 
   // Perform query against global secondary index
   GameScore
-  .query('Galaxy Invaders')
-  .usingIndex('GameTitleIndex')
-  .where('topScore').gt(0)
-  .descending()
-  .exec((err, data) => {
-    if (err) {
-      console.log(err);
-    } else {
-      console.log('Found', data.Count, 'items');
-      console.log(util.inspect(_.pluck(data.Items, 'attrs')));
-    }
-  });
+    .query('Galaxy Invaders')
+    .usingIndex('GameTitleIndex')
+    .where('topScore').gt(0)
+    .descending()
+    .exec((err, data) => {
+      if (err) {
+        console.log(err);
+      } else {
+        console.log('Found', data.Count, 'items');
+        console.log(util.inspect(_.pluck(data.Items, 'attrs')));
+      }
+    });
 });

--- a/examples/hooks.js
+++ b/examples/hooks.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const dynogels = require('../index');
-const AWS = dynogels.AWS;
 const Joi = require('joi');
 
+const AWS = dynogels.AWS;
 AWS.config.loadFromPath(`${process.env.HOME}/.ec2/credentials.json`);
 
 const Account = dynogels.define('example-hook', {
@@ -29,19 +29,19 @@ Account.before('update', (data, next) => {
   return next(null, data);
 });
 
-Account.after('create', item => {
+Account.after('create', (item) => {
   console.log('Account created', item.get());
 });
 
-Account.after('update', item => {
+Account.after('update', (item) => {
   console.log('Account updated', item.get());
 });
 
-Account.after('destroy', item => {
+Account.after('destroy', (item) => {
   console.log('Account destroyed', item.get());
 });
 
-dynogels.createTables(err => {
+dynogels.createTables((err) => {
   if (err) {
     console.log('Error creating tables', err);
     process.exit(1);

--- a/examples/modelMethods.js
+++ b/examples/modelMethods.js
@@ -2,8 +2,8 @@
 
 const dynogels = require('../index');
 const Joi = require('joi');
-const AWS = dynogels.AWS;
 
+const AWS = dynogels.AWS;
 AWS.config.loadFromPath(`${process.env.HOME}/.ec2/credentials.json`);
 
 const Account = dynogels.define('example-model-methods-Account', {
@@ -17,17 +17,17 @@ const Account = dynogels.define('example-model-methods-Account', {
 });
 
 Account.prototype.sayHello = function () {
-  console.log(`Hello my name is ${this.get('name')} I\'m ${this.get('age')} years old`);
+  console.log(`Hello my name is ${this.get('name')} I'm ${this.get('age')} years old`);
 };
 
 Account.findByAgeRange = (low, high) => {
   Account.scan()
-  .where('age').gte(low)
-  .where('age').lte(high)
-  .loadAll()
-  .exec((err, data) => {
-    data.Items.forEach(account => {
-      account.sayHello();
+    .where('age').gte(low)
+    .where('age').lte(high)
+    .loadAll()
+    .exec((err, data) => {
+      data.Items.forEach((account) => {
+        account.sayHello();
+      });
     });
-  });
 };

--- a/examples/nestedAttributes.js
+++ b/examples/nestedAttributes.js
@@ -5,8 +5,8 @@ const util = require('util');
 const _ = require('lodash');
 const async = require('async');
 const Joi = require('joi');
-const AWS = dynogels.AWS;
 
+const AWS = dynogels.AWS;
 AWS.config.loadFromPath(`${process.env.HOME}/.ec2/credentials.json`);
 
 const Movie = dynogels.define('example-nested-attribute', {
@@ -39,7 +39,7 @@ const printResults = (err, data) => {
   console.log('----------------------------------------------------------------------');
 };
 
-const loadSeedData = callback => {
+const loadSeedData = (callback) => {
   callback = callback || _.noop;
 
   async.times(10, (n, next) => {
@@ -101,7 +101,7 @@ const runExample = () => {
 async.series([
   async.apply(dynogels.createTables.bind(dynogels)),
   loadSeedData
-], err => {
+], (err) => {
   if (err) {
     console.log('error', err);
     process.exit(1);

--- a/examples/optionalAttributes.js
+++ b/examples/optionalAttributes.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const dynogels = require('../index');
-const AWS = dynogels.AWS;
 const Joi = require('joi');
 
+const AWS = dynogels.AWS;
 AWS.config.loadFromPath(`${process.env.HOME}/.ec2/credentials.json`);
 
 const Person = dynogels.define('example-optional-attribute', {
@@ -24,7 +24,7 @@ const printInfo = (err, person) => {
   }
 };
 
-dynogels.createTables(err => {
+dynogels.createTables((err) => {
   if (err) {
     console.log('Failed to create table', err);
     process.exit(1);

--- a/examples/parallelscan.js
+++ b/examples/parallelscan.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const dynogels = require('../index');
-const AWS = dynogels.AWS;
 const _ = require('lodash');
 const Joi = require('joi');
 const async = require('async');
 
+const AWS = dynogels.AWS;
 AWS.config.loadFromPath(`${process.env.HOME}/.ec2/credentials.json`);
 
 const Product = dynogels.define('example-parallel-scan', {
@@ -37,7 +37,7 @@ const printInfo = (err, resp) => {
   console.log('Average purchased price', totalPrices / resp.Count);
 };
 
-const loadSeedData = callback => {
+const loadSeedData = (callback) => {
   callback = callback || _.noop;
 
   async.times(30, (n, next) => {
@@ -50,15 +50,15 @@ const runParallelScan = () => {
   const totalSegments = 8;
 
   Product.parallelScan(totalSegments)
-  .where('purchased').equals(true)
-  .attributes('price')
-  .exec(printInfo);
+    .where('purchased').equals(true)
+    .attributes('price')
+    .exec(printInfo);
 };
 
 async.series([
   async.apply(dynogels.createTables.bind(dynogels)),
   loadSeedData
-], err => {
+], (err) => {
   if (err) {
     console.log('error', err);
     process.exit(1);

--- a/examples/query.js
+++ b/examples/query.js
@@ -5,8 +5,8 @@ const util = require('util');
 const _ = require('lodash');
 const async = require('async');
 const Joi = require('joi');
-const AWS = dynogels.AWS;
 
+const AWS = dynogels.AWS;
 AWS.config.loadFromPath(`${process.env.HOME}/.ec2/credentials.json`);
 
 const Account = dynogels.define('example-query', {
@@ -41,7 +41,7 @@ const printResults = (err, resp) => {
   console.log('----------------------------------------------------------------------');
 };
 
-const loadSeedData = callback => {
+const loadSeedData = (callback) => {
   callback = callback || _.noop;
 
   async.times(25, (n, next) => {
@@ -59,29 +59,29 @@ const runQueries = () => {
 
   // Query with rang key condition
   Account.query('Test 1')
-  .where('email').beginsWith('foo')
-  .exec(printResults);
+    .where('email').beginsWith('foo')
+    .exec(printResults);
 
   // Run query returning only email and created attributes
   // also returns consumed capacity query took
   Account.query('Test 2')
-  .where('email').gte('a@example.com')
-  .attributes(['email', 'createdAt'])
-  .returnConsumedCapacity()
-  .exec(printResults);
+    .where('email').gte('a@example.com')
+    .attributes(['email', 'createdAt'])
+    .returnConsumedCapacity()
+    .exec(printResults);
 
   // Run query against secondary index
   Account.query('Test 0')
-  .usingIndex('CreatedAtIndex')
-  .where('createdAt').lt(new Date().toISOString())
-  .descending()
-  .exec(printResults);
+    .usingIndex('CreatedAtIndex')
+    .where('createdAt').lt(new Date().toISOString())
+    .descending()
+    .exec(printResults);
 };
 
 async.series([
   async.apply(dynogels.createTables.bind(dynogels)),
   loadSeedData
-], err => {
+], (err) => {
   if (err) {
     console.log('error', err);
     process.exit(1);

--- a/examples/queryFilter.js
+++ b/examples/queryFilter.js
@@ -5,8 +5,8 @@ const util = require('util');
 const _ = require('lodash');
 const Joi = require('joi');
 const async = require('async');
-const AWS = dynogels.AWS;
 
+const AWS = dynogels.AWS;
 AWS.config.loadFromPath(`${process.env.HOME}/.ec2/credentials.json`);
 
 const Account = dynogels.define('example-query-filter', {
@@ -42,7 +42,7 @@ const printResults = msg => (err, resp) => {
   console.log('----------------------------------------------------------------------');
 };
 
-const loadSeedData = callback => {
+const loadSeedData = (callback) => {
   callback = callback || _.noop;
 
   async.times(30, (n, next) => {
@@ -76,7 +76,7 @@ const runFilterQueries = () => {
 async.series([
   async.apply(dynogels.createTables.bind(dynogels)),
   loadSeedData
-], err => {
+], (err) => {
   if (err) {
     console.log('error', err);
     process.exit(1);

--- a/examples/scan.js
+++ b/examples/scan.js
@@ -3,10 +3,10 @@
 const dynogels = require('../index');
 const util = require('util');
 const _ = require('lodash');
-const AWS = dynogels.AWS;
 const async = require('async');
 const Joi = require('joi');
 
+const AWS = dynogels.AWS;
 AWS.config.loadFromPath(`${process.env.HOME}/.ec2/credentials.json`);
 
 const Account = dynogels.define('example-scan', {
@@ -38,7 +38,7 @@ const printResults = (err, resp) => {
   console.log('----------------------------------------------------------------------');
 };
 
-const loadSeedData = callback => {
+const loadSeedData = (callback) => {
   callback = callback || _.noop;
 
   async.times(30, (n, next) => {
@@ -57,26 +57,26 @@ const runScans = () => {
 
   // Scan with key condition
   Account.scan()
-  .where('email').beginsWith('test5')
-  .exec(printResults);
+    .where('email').beginsWith('test5')
+    .exec(printResults);
 
   // Run scan returning only email and created attributes
   // also returns consumed capacity the scan took
   Account.scan()
-  .where('email').gte('f@example.com')
-  .attributes(['email', 'createdAt'])
-  .returnConsumedCapacity()
-  .exec(printResults);
+    .where('email').gte('f@example.com')
+    .attributes(['email', 'createdAt'])
+    .returnConsumedCapacity()
+    .exec(printResults);
 
   Account.scan()
-  .where('scores').contains(2)
-  .exec(printResults);
+    .where('scores').contains(2)
+    .exec(printResults);
 };
 
 async.series([
   async.apply(dynogels.createTables.bind(dynogels)),
   loadSeedData
-], err => {
+], (err) => {
   if (err) {
     console.log('error', err);
     process.exit(1);

--- a/examples/streaming.js
+++ b/examples/streaming.js
@@ -2,8 +2,8 @@
 
 const dynogels = require('../index');
 const Joi = require('joi');
-const AWS = dynogels.AWS;
 
+const AWS = dynogels.AWS;
 AWS.config.loadFromPath(`${process.env.HOME}/.ec2/credentials.json`);
 
 const Product = dynogels.define('example-streaming-Product', {
@@ -19,12 +19,12 @@ const Product = dynogels.define('example-streaming-Product', {
 
 const printStream = (msg, stream) => {
   let count = 0;
-  stream.on('error', err => {
+  stream.on('error', (err) => {
     console.log(`error ${msg}`, err);
   });
 
   stream.on('readable', () => {
-    count++;
+    count += 1;
     console.log(`----------------------${count}--------------------------`);
     console.log(`Scanned ${stream.read().Count} products - ${msg}`);
   });

--- a/examples/update.js
+++ b/examples/update.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const dynogels = require('../index');
-const AWS = dynogels.AWS;
 const Joi = require('joi');
 
+const AWS = dynogels.AWS;
 AWS.config.loadFromPath(`${process.env.HOME}/.ec2/credentials.json`);
 
 const Account = dynogels.define('example-update', {
@@ -18,7 +18,7 @@ const Account = dynogels.define('example-update', {
   }
 });
 
-dynogels.createTables(err => {
+dynogels.createTables((err) => {
   if (err) {
     console.log('Error creating tables', err);
     process.exit(1);

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -37,7 +37,7 @@ internals.paginatedRequest = (request, table, callback) => {
 
   const moreKeysToProcessFunc = () => request !== null && !_.isEmpty(request);
 
-  const doFunc = callback => {
+  const doFunc = (callback) => {
     table.runBatchGetItems(request, (err, resp) => {
       if (err && err.retryable) {
         return callback();
@@ -55,7 +55,7 @@ internals.paginatedRequest = (request, table, callback) => {
     });
   };
 
-  const resulsFunc = err => {
+  const resulsFunc = (err) => {
     if (err) {
       return callback(err);
     }
@@ -66,7 +66,7 @@ internals.paginatedRequest = (request, table, callback) => {
   async.doWhilst(doFunc, moreKeysToProcessFunc, resulsFunc);
 };
 
-internals.buckets = keys => {
+internals.buckets = (keys) => {
   const buckets = [];
 
   while (keys.length) {

--- a/lib/createTables.js
+++ b/lib/createTables.js
@@ -14,7 +14,7 @@ internals.createTable = (model, globalOptions, options, callback) => {
   model.describeTable((err, data) => {
     if (_.isNull(data) || _.isUndefined(data)) {
       model.log.info('creating table: %s', tableName);
-      return model.createTable(options, error => {
+      return model.createTable(options, (error) => {
         if (error) {
           model.log.warn({ err: error }, 'failed to create table %s: %s', tableName, error);
           return callback(error);
@@ -24,7 +24,7 @@ internals.createTable = (model, globalOptions, options, callback) => {
         internals.waitTillActive(globalOptions, model, callback);
       });
     } else {
-      model.updateTable(err => {
+      model.updateTable((err) => {
         if (err) {
           model.log.warn({ err: err }, 'failed to update table %s: %s', tableName, err);
           return callback(err);
@@ -41,7 +41,7 @@ internals.waitTillActive = (options, model, callback) => {
   let status = 'PENDING';
 
   async.doWhilst(
-    callback => {
+    (callback) => {
       model.describeTable((err, data) => {
         if (err) {
           return callback(err);
@@ -52,8 +52,9 @@ internals.waitTillActive = (options, model, callback) => {
         setTimeout(callback, options.pollingInterval || 1000);
       });
     },
-  () => status !== 'ACTIVE',
-  err => callback(err));
+    () => status !== 'ACTIVE',
+    err => callback(err)
+  );
 };
 
 module.exports = (models, config, callback) => {

--- a/lib/expressions.js
+++ b/lib/expressions.js
@@ -87,7 +87,7 @@ exports.stringify = expressions => _.reduce(expressions, (result, value, key) =>
   return result;
 }, []).join(' ');
 
-internals.formatAttributeValue = val => {
+internals.formatAttributeValue = (val) => {
   if (_.isDate(val)) {
     return val.toISOString();
   }
@@ -95,13 +95,18 @@ internals.formatAttributeValue = val => {
   return val;
 };
 
-internals.isFunctionOperator = operator => _.includes(['attribute_exists',
-                   'attribute_not_exists',
-                   'attribute_type',
-                   'begins_with',
-                   'contains',
-                   'NOT contains',
-                   'size'], operator);
+internals.isFunctionOperator = operator => _.includes(
+  [
+    'attribute_exists',
+    'attribute_not_exists',
+    'attribute_type',
+    'begins_with',
+    'contains',
+    'NOT contains',
+    'size'
+  ],
+  operator
+);
 
 internals.uniqAttributeValueName = (key, existingValueNames) => {
   const cleanedKey = key.replace(/\./g, '_').replace(/\W/g, '');
@@ -109,7 +114,7 @@ internals.uniqAttributeValueName = (key, existingValueNames) => {
   let idx = 1;
 
   while (_.includes(existingValueNames, potentialName)) {
-    idx++;
+    idx += 1;
     potentialName = `:${cleanedKey}_${idx}`;
   }
 
@@ -133,7 +138,7 @@ exports.buildFilterExpression = (key, operator, existingValueNames, val1, val2) 
   }
 
   const keys = key.split('.');
-  const path = `#${keys.join('.#').replace(/[^\w\.#]/g, '')}`;
+  const path = `#${keys.join('.#').replace(/[^\w.#]/g, '')}`;
   const v1ValueName = internals.uniqAttributeValueName(key, existingValueNames);
   const v2ValueName = internals.uniqAttributeValueName(key, [v1ValueName].concat(existingValueNames));
 
@@ -163,7 +168,7 @@ exports.buildFilterExpression = (key, operator, existingValueNames, val1, val2) 
 
   const attributeNames = {};
   keys.forEach((key) => {
-    attributeNames[`#${key.replace(/[^\w\.]/g, '')}`] = key;
+    attributeNames[`#${key.replace(/[^\w.]/g, '')}`] = key;
   });
 
   return {

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,6 @@
 const _ = require('lodash');
 const util = require('util');
 const AWS = require('aws-sdk');
-const DocClient = AWS.DynamoDB.DocumentClient;
 const Table = require('./table');
 const Schema = require('./schema');
 const serializer = require('./serializer');
@@ -11,6 +10,7 @@ const batch = require('./batch');
 const Item = require('./item');
 const createTables = require('./createTables');
 
+const DocClient = AWS.DynamoDB.DocumentClient;
 const dynogels = module.exports;
 
 dynogels.AWS = AWS;
@@ -22,7 +22,7 @@ dynogels.log = dynogels.log || {
   warn: () => null,
 };
 
-dynogels.dynamoDriver = internals.dynamoDriver = driver => {
+dynogels.dynamoDriver = internals.dynamoDriver = (driver) => {
   if (driver) {
     internals.dynamodb = driver;
 
@@ -35,7 +35,7 @@ dynogels.dynamoDriver = internals.dynamoDriver = driver => {
   return internals.dynamodb;
 };
 
-dynogels.documentClient = internals.documentClient = docClient => {
+dynogels.documentClient = internals.documentClient = (docClient) => {
   if (docClient) {
     internals.docClient = docClient;
     internals.dynamodb = docClient.service;
@@ -47,13 +47,13 @@ dynogels.documentClient = internals.documentClient = docClient => {
   return internals.docClient;
 };
 
-internals.updateDynamoDBDocClientForAllModels = docClient => {
-  _.each(dynogels.models, model => {
+internals.updateDynamoDBDocClientForAllModels = (docClient) => {
+  _.each(dynogels.models, (model) => {
     model.config({ docClient: docClient });
   });
 };
 
-internals.loadDocClient = driver => {
+internals.loadDocClient = (driver) => {
   if (driver) {
     internals.docClient = new DocClient({ service: driver });
   } else {
@@ -102,10 +102,12 @@ internals.compileModel = (name, schema, log) => {
   Model.after = _.bind(table.after, table);
   Model.before = _.bind(table.before, table);
 
-  Model.__defineGetter__('docClient', () => table.docClient);
-  Model.__defineGetter__('schema', () => table.schema);
+  Object.defineProperties(Model, {
+    docClient: { get: () => table.docClient },
+    schema: { get: () => table.schema }
+  });
 
-  Model.config = config => {
+  Model.config = (config) => {
     config = config || {};
 
     if (config.tableName) {

--- a/lib/parallelScan.js
+++ b/lib/parallelScan.js
@@ -23,7 +23,7 @@ ParallelScan.prototype.exec = function (callback) {
 
   if (!callback) {
     streamMode = true;
-    callback = err => {
+    callback = (err) => {
       if (err) {
         combinedStream.emit('error', err);
       }
@@ -31,13 +31,13 @@ ParallelScan.prototype.exec = function (callback) {
   }
 
   const scanFuncs = [];
-  _.times(self.totalSegments, segment => {
+  _.times(self.totalSegments, (segment) => {
     let scn = new Scan(self.table, self.serializer);
     scn.request = _.cloneDeep(self.request);
 
     scn = scn.segments(segment, self.totalSegments).loadAll();
 
-    const scanFunc = callback => {
+    const scanFunc = (callback) => {
       if (streamMode) {
         const stream = scn.exec();
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -165,7 +165,7 @@ Query.prototype.buildKey = function () {
   return expressions.buildFilterExpression(key, '=', existingValueKeys, this.hashKey);
 };
 
-internals.formatAttributeValue = val => {
+internals.formatAttributeValue = (val) => {
   if (_.isDate(val)) {
     return val.toISOString();
   }

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -44,7 +44,7 @@ internals.configSchema = Joi.object().keys({
   }
 }).required();
 
-internals.wireType = key => {
+internals.wireType = (key) => {
   switch (key) {
     case 'string':
       return 'S';
@@ -63,7 +63,7 @@ internals.wireType = key => {
   }
 };
 
-internals.findDynamoTypeMetadata = data => {
+internals.findDynamoTypeMetadata = (data) => {
   const meta = _.find(data.meta, data => _.isString(data.dynamoType));
 
   if (meta) {
@@ -73,7 +73,7 @@ internals.findDynamoTypeMetadata = data => {
   }
 };
 
-internals.parseDynamoTypes = data => {
+internals.parseDynamoTypes = (data) => {
   if (_.isPlainObject(data) && data.type === 'object' && _.isPlainObject(data.children)) {
     return internals.parseDynamoTypes(data.children);
   }
@@ -188,7 +188,7 @@ Schema.prototype.validate = function (params, options) {
   return Joi.validate(params, this._modelSchema, options);
 };
 
-internals.invokeDefaultFunctions = data => _.mapValues(data, val => {
+internals.invokeDefaultFunctions = data => _.mapValues(data, (val) => {
   if (_.isPlainObject(val)) {
     return internals.invokeDefaultFunctions(val);
   } else {

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -10,7 +10,7 @@ const internals = {};
 
 internals.docClient = new AWS.DynamoDB.DocumentClient();
 
-internals.createSet = value => {
+internals.createSet = (value) => {
   if (_.isArray(value)) {
     return internals.docClient.createSet(value);
   } else {
@@ -63,7 +63,7 @@ const serialize = internals.serialize = {
   }
 };
 
-internals.deserializeAttribute = value => {
+internals.deserializeAttribute = (value) => {
   if (_.isObject(value) && _.isFunction(value.detectType) && _.isArray(value.values)) {
     // value is a Set object from document client
     return value.values;
@@ -72,7 +72,7 @@ internals.deserializeAttribute = value => {
   }
 };
 
-internals.serializeAttribute = serializer.serializeAttribute = (value, type, options) => {
+internals.serializeAttribute = serializer.serializeAttribute = (value, type) => {
   if (!type) { // if type is unknown, possibly because its an dynamic key return given value
     return value;
   }
@@ -80,8 +80,6 @@ internals.serializeAttribute = serializer.serializeAttribute = (value, type, opt
   if (_.isNull(value)) {
     return null;
   }
-
-  options = options || {};
 
   switch (type) {
     case 'DATE':
@@ -110,7 +108,7 @@ serializer.buildKey = (hashKey, rangeKey, schema) => {
     if (schema.rangeKey && !_.isNull(hashKey[schema.rangeKey]) && !_.isUndefined(hashKey[schema.rangeKey])) {
       obj[schema.rangeKey] = hashKey[schema.rangeKey];
     }
-    _.each(schema.globalIndexes, keys => {
+    _.each(schema.globalIndexes, (keys) => {
       if (_.has(hashKey, keys.hashKey)) {
         obj[keys.hashKey] = hashKey[keys.hashKey];
       }
@@ -120,7 +118,7 @@ serializer.buildKey = (hashKey, rangeKey, schema) => {
       }
     });
 
-    _.each(schema.secondaryIndexes, keys => {
+    _.each(schema.secondaryIndexes, (keys) => {
       if (_.has(hashKey, keys.rangeKey)) {
         obj[keys.rangeKey] = hashKey[keys.rangeKey];
       }
@@ -193,19 +191,19 @@ serializer.serializeItemForUpdate = (schema, action, item) => {
   }, {});
 };
 
-serializer.deserializeItem = item => {
+serializer.deserializeItem = (item) => {
   if (_.isNull(item)) {
     return null;
   }
 
-  const formatter = data => {
+  const formatter = (data) => {
     let map = _.mapValues;
 
     if (_.isArray(data)) {
       map = _.map;
     }
 
-    return map(data, value => {
+    return map(data, (value) => {
       let result;
 
       if (_.isPlainObject(value)) {

--- a/lib/table.js
+++ b/lib/table.js
@@ -138,7 +138,7 @@ Table.prototype.create = function (item, options, callback) {
 internals.createItem = (table, item, options, callback) => {
   const self = table;
 
-  const start = callback => {
+  const start = (callback) => {
     const data = self.schema.applyDefaults(item);
 
     const paramName = _.isString(self.schema.createdAt) ? self.schema.createdAt : 'createdAt';
@@ -187,7 +187,7 @@ internals.createItem = (table, item, options, callback) => {
 
     params = _.merge({}, params, options);
 
-    self.sendRequest('put', params, err => {
+    self.sendRequest('put', params, (err) => {
       if (err) {
         return callback(err);
       }
@@ -307,7 +307,7 @@ Table.prototype.update = function (item, options, callback) {
     }));
   }
 
-  const start = callback => {
+  const start = (callback) => {
     const paramName = _.isString(self.schema.updatedAt) ? self.schema.updatedAt : 'updatedAt';
 
     if (self.schema.timestamps && self.schema.updatedAt !== false && !_.has(item, paramName)) {
@@ -583,7 +583,7 @@ Table.prototype.dynamoCreateTableParams = function (options) {
 
   const localSecondaryIndexes = [];
 
-  _.forEach(self.schema.secondaryIndexes, params => {
+  _.forEach(self.schema.secondaryIndexes, (params) => {
     attributeDefinitions.push(internals.attributeDefinition(self.schema, params.rangeKey));
     localSecondaryIndexes.push(internals.secondaryIndex(self.schema, params));
   });
@@ -622,7 +622,7 @@ Table.prototype.dynamoCreateTableParams = function (options) {
     params.GlobalSecondaryIndexes = globalSecondaryIndexes;
   }
 
-  if (options.hasOwnProperty('streamSpecification') && typeof options.streamSpecification === 'object') {
+  if (Object.prototype.hasOwnProperty.call(options, 'streamSpecification') && typeof options.streamSpecification === 'object') {
     params.StreamSpecification = {
       StreamEnabled: options.streamSpecification.streamEnabled || false
     };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -67,7 +67,7 @@ utils.paginatedRequest = (self, runRequestFunc, callback) => {
   const responses = [];
   let retry = false;
 
-  const doFunc = callback => {
+  const doFunc = (callback) => {
     if (lastEvaluatedKey) {
       self.startKey(lastEvaluatedKey);
     }
@@ -92,7 +92,7 @@ utils.paginatedRequest = (self, runRequestFunc, callback) => {
 
   const testFunc = () => (self.options.loadAll && lastEvaluatedKey) || retry;
 
-  const resulsFunc = err => {
+  const resulsFunc = (err) => {
     if (err) {
       return callback(err);
     }
@@ -149,8 +149,8 @@ utils.streamRequest = (self, runRequestFunc) => {
 
 utils.omitPrimaryKeys = (schema, params) => _.omit(params, schema.hashKey, schema.rangeKey);
 
-utils.strToBin = value => {
-  if (typeof(value) !== 'string') {
+utils.strToBin = (value) => {
+  if (typeof value !== 'string') {
     const StrConversionError = 'Need to pass in string primitive to be converted to binary.';
     throw new Error(StrConversionError);
   }
@@ -158,7 +158,7 @@ utils.strToBin = value => {
   if (AWS.util.isBrowser()) {
     const len = value.length;
     const bin = new Uint8Array(new ArrayBuffer(len));
-    for (let i = 0; i < len; i++) {
+    for (let i = 0; i < len; i += 1) {
       bin[i] = value.charCodeAt(i);
     }
     return bin;

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   "devDependencies": {
     "chai": "4.1.2",
     "coveralls": "3.0.0",
-    "eslint": "^2.13.1",
-    "eslint-config-airbnb-base": "^3.0.1",
-    "eslint-plugin-import": "^1.11.1",
+    "eslint": "4.19.1",
+    "eslint-config-airbnb-base": "12.1.0",
+    "eslint-plugin-import": "2.10.0",
     "istanbul": "^0.4.4",
     "jscoverage": "^0.6.0",
     "mocha": "4.0.1",

--- a/test/batch-test.js
+++ b/test/batch-test.js
@@ -2,13 +2,14 @@
 
 const helper = require('./test-helper');
 const chai = require('chai');
-const expect = chai.expect;
 const Schema = require('../lib/schema');
 const Item = require('../lib/item');
 const batch = require('../lib/batch');
 const Serializer = require('../lib/serializer');
 const Joi = require('joi');
 const _ = require('lodash');
+
+const expect = chai.expect;
 
 describe('Batch', () => {
   let serializer;
@@ -35,7 +36,7 @@ describe('Batch', () => {
   });
 
   describe('#getItems', () => {
-    it('should get items by hash key', done => {
+    it('should get items by hash key', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -79,7 +80,7 @@ describe('Batch', () => {
       });
     });
 
-    it('should get items by hash and range key', done => {
+    it('should get items by hash and range key', (done) => {
       const key1 = { email: 'test@test.com', name: 'Tim Tester' };
       const key2 = { email: 'foo@example.com', name: 'Foo Bar' };
 
@@ -116,8 +117,8 @@ describe('Batch', () => {
       });
     });
 
-    it('should not modify passed in keys', done => {
-      const keys = _.map(_.range(100), num => {
+    it('should not modify passed in keys', (done) => {
+      const keys = _.map(_.range(100), (num) => {
         const key = { email: `test${num}@test.com`, name: `Test ${num}` };
         serializer.buildKey.withArgs(key).returns({ email: { S: key.email }, name: { S: key.name } });
 
@@ -131,7 +132,7 @@ describe('Batch', () => {
       table.initItem.returns(new Item(item1));
 
       batch(table, serializer).getItems(keys, () => {
-        _.each(_.range(100), num => {
+        _.each(_.range(100), (num) => {
           const key = { email: `test${num}@test.com`, name: `Test ${num}` };
           keys[num].should.eql(key);
         });
@@ -140,7 +141,7 @@ describe('Batch', () => {
       });
     });
 
-    it('should get items by hash key with consistent read', done => {
+    it('should get items by hash key with consistent read', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -185,7 +186,7 @@ describe('Batch', () => {
       });
     });
 
-    it('should get items by hash key with projection expression', done => {
+    it('should get items by hash key with projection expression', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -236,7 +237,7 @@ describe('Batch', () => {
       });
     });
 
-    it('should get items when encounters retryable excpetion', done => {
+    it('should get items when encounters retryable excpetion', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -279,7 +280,7 @@ describe('Batch', () => {
     });
 
 
-    it('should get unprocessed keys', done => {
+    it('should get unprocessed keys', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -354,7 +355,7 @@ describe('Batch', () => {
       });
     });
 
-    it('should return error', done => {
+    it('should return error', (done) => {
       const config = {
         hashKey: 'email',
         schema: {

--- a/test/expressions-test.js
+++ b/test/expressions-test.js
@@ -2,9 +2,10 @@
 
 const expressions = require('../lib/expressions');
 const chai = require('chai');
-const expect = chai.expect;
 const Schema = require('../lib/schema');
 const Joi = require('joi');
+
+const expect = chai.expect;
 
 chai.should();
 

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -5,9 +5,10 @@ const AWS = require('aws-sdk');
 const helper = require('./test-helper');
 const Table = require('../lib/table');
 const chai = require('chai');
-const expect = chai.expect;
 const Joi = require('joi');
 const sinon = require('sinon');
+
+const expect = chai.expect;
 
 chai.should();
 
@@ -31,7 +32,7 @@ describe('dynogels', () => {
 
     it('should throw when using old api', () => {
       expect(() => {
-        dynogels.define('Account', schema => {
+        dynogels.define('Account', (schema) => {
           schema.String('email', { hashKey: true });
         });
       }).to.throw(/define no longer accepts schema callback, migrate to new api/);
@@ -176,7 +177,7 @@ describe('dynogels', () => {
 
       dynamodb.createTable.yields(null, null);
 
-      dynogels.createTables(err => {
+      dynogels.createTables((err) => {
         expect(err).to.not.exist;
         expect(dynamodb.describeTable.calledThrice).to.be.true;
         return done();
@@ -186,7 +187,7 @@ describe('dynogels', () => {
       clock.tick(1200);
     });
 
-    it('should return error', done => {
+    it('should return error', (done) => {
       const Account = dynogels.define('Account', { hashKey: 'id' });
 
       const dynamodb = Account.docClient.service;
@@ -194,14 +195,14 @@ describe('dynogels', () => {
 
       dynamodb.createTable.yields(new Error('Fail'), null);
 
-      dynogels.createTables(err => {
+      dynogels.createTables((err) => {
         expect(err).to.exist;
         expect(dynamodb.describeTable.calledOnce).to.be.true;
         return done();
       });
     });
 
-    it('should create model without callback', done => {
+    it('should create model without callback', (done) => {
       const Account = dynogels.define('Account', { hashKey: 'id' });
       const dynamodb = Account.docClient.service;
 
@@ -229,7 +230,7 @@ describe('dynogels', () => {
       return done();
     });
 
-    it('should return error when waiting for table to become active', done => {
+    it('should return error when waiting for table to become active', (done) => {
       const Account = dynogels.define('Account', { hashKey: 'id' });
       const dynamodb = Account.docClient.service;
 
@@ -244,7 +245,7 @@ describe('dynogels', () => {
 
       dynamodb.createTable.yields(null, null);
 
-      dynogels.createTables(err => {
+      dynogels.createTables((err) => {
         expect(err).to.exist;
         expect(dynamodb.describeTable.calledThrice).to.be.true;
         return done();

--- a/test/integration/create-table-test.js
+++ b/test/integration/create-table-test.js
@@ -2,10 +2,11 @@
 
 const dynogels = require('../../index');
 const chai = require('chai');
-const expect = chai.expect;
 const _ = require('lodash');
 const helper = require('../test-helper');
 const Joi = require('joi');
+
+const expect = chai.expect;
 
 chai.should();
 
@@ -20,7 +21,7 @@ describe('Create Tables Integration Tests', function () {
     dynogels.reset();
   });
 
-  it('should create table with hash key', done => {
+  it('should create table with hash key', (done) => {
     const Model = dynogels.define('dynogels-create-table-test', {
       hashKey: 'id',
       tableName: helper.randomName('dynogels-createtable-Accounts'),
@@ -44,7 +45,7 @@ describe('Create Tables Integration Tests', function () {
     });
   });
 
-  it('should create table with hash and range key', done => {
+  it('should create table with hash and range key', (done) => {
     const Model = dynogels.define('dynogels-createtable-rangekey', {
       hashKey: 'name',
       rangeKey: 'age',
@@ -76,7 +77,7 @@ describe('Create Tables Integration Tests', function () {
     });
   });
 
-  it('should create table with local secondary index', done => {
+  it('should create table with local secondary index', (done) => {
     const Model = dynogels.define('dynogels-createtable-rangekey', {
       hashKey: 'name',
       rangeKey: 'age',
@@ -134,7 +135,7 @@ describe('Create Tables Integration Tests', function () {
     });
   });
 
-  it('should create table with local secondary index with custom projection', done => {
+  it('should create table with local secondary index with custom projection', (done) => {
     const Model = dynogels.define('dynogels-createtable-local-proj', {
       hashKey: 'name',
       rangeKey: 'age',
@@ -183,7 +184,7 @@ describe('Create Tables Integration Tests', function () {
     });
   });
 
-  it('should create table with global index', done => {
+  it('should create table with global index', (done) => {
     const Model = dynogels.define('dynogels-createtable-global', {
       hashKey: 'name',
       rangeKey: 'age',
@@ -226,7 +227,7 @@ describe('Create Tables Integration Tests', function () {
     });
   });
 
-  it('should create table with global index with optional settings', done => {
+  it('should create table with global index with optional settings', (done) => {
     const Model = dynogels.define('dynogels-createtable-global', {
       hashKey: 'name',
       rangeKey: 'age',
@@ -277,7 +278,7 @@ describe('Create Tables Integration Tests', function () {
     });
   });
 
-  it('should create table with global and local indexes', done => {
+  it('should create table with global and local indexes', (done) => {
     const Model = dynogels.define('dynogels-createtable-both-indexes', {
       hashKey: 'name',
       rangeKey: 'age',
@@ -362,7 +363,7 @@ describe('Update Tables Integration Tests', function () {
   let Tweet;
   let tableName;
 
-  before(done => {
+  before((done) => {
     dynogels.dynamoDriver(helper.realDynamoDB());
 
     tableName = helper.randomName('dynogels-updateTable-Tweets');
@@ -386,7 +387,7 @@ describe('Update Tables Integration Tests', function () {
     dynogels.reset();
   });
 
-  it('should add global secondary index', done => {
+  it('should add global secondary index', (done) => {
     Tweet = dynogels.define('dynogels-update-table-test', {
       hashKey: 'UserId',
       rangeKey: 'TweetID',
@@ -402,7 +403,7 @@ describe('Update Tables Integration Tests', function () {
       ]
     });
 
-    Tweet.updateTable(err => {
+    Tweet.updateTable((err) => {
       expect(err).to.not.exist;
 
       Tweet.describeTable((err, data) => {
@@ -413,8 +414,10 @@ describe('Update Tables Integration Tests', function () {
 
         const idx = _.first(globalIndexes);
         expect(idx.IndexName).to.eql('PublishedDateTimeIndex');
-        expect(idx.KeySchema).to.eql([{ AttributeName: 'UserId', KeyType: 'HASH' },
-                                      { AttributeName: 'PublishedDateTime', KeyType: 'RANGE' }]);
+        expect(idx.KeySchema).to.eql([
+          { AttributeName: 'UserId', KeyType: 'HASH' },
+          { AttributeName: 'PublishedDateTime', KeyType: 'RANGE' }
+        ]);
         expect(idx.Projection).to.eql({ ProjectionType: 'ALL' });
 
         return done();

--- a/test/integration/integration-test.js
+++ b/test/integration/integration-test.js
@@ -2,12 +2,13 @@
 
 const dynogels = require('../../index');
 const chai = require('chai');
-const expect = chai.expect;
 const async = require('async');
 const _ = require('lodash');
 const helper = require('../test-helper');
 const uuid = require('uuid');
 const Joi = require('joi');
+
+const expect = chai.expect;
 
 chai.should();
 
@@ -19,11 +20,11 @@ const internals = {};
 
 internals.userId = n => `userid-${n}`;
 
-internals.loadSeedData = callback => {
+internals.loadSeedData = (callback) => {
   callback = callback || _.noop;
 
   async.parallel([
-    callback => {
+    (callback) => {
       async.times(15, (n, next) => {
         let roles = ['user'];
         if (n % 3 === 0) {
@@ -35,7 +36,7 @@ internals.loadSeedData = callback => {
         User.create({ id: internals.userId(n), email: `test${n}@example.com`, name: `Test ${n % 3}`, age: n + 10, roles: roles }, next);
       }, callback);
     },
-    callback => {
+    (callback) => {
       async.times(15 * 5, (n, next) => {
         const userId = internals.userId(n % 5);
         const p = { UserId: userId, content: `I love tweeting, in fact Ive tweeted ${n} times`, num: n };
@@ -46,11 +47,11 @@ internals.loadSeedData = callback => {
         return Tweet.create(p, next);
       }, callback);
     },
-    callback => {
+    (callback) => {
       async.times(10, (n, next) => {
         const director = { firstName: 'Steven', lastName: `Spielberg the ${n}`, titles: ['Producer', 'Writer', 'Director'] };
         const actors = [
-        { firstName: 'Tom', lastName: 'Hanks', titles: ['Producer', 'Actor', 'Soundtrack'] }
+          { firstName: 'Tom', lastName: 'Hanks', titles: ['Producer', 'Actor', 'Soundtrack'] }
         ];
 
         const tags = [`tag ${n}`];
@@ -74,7 +75,7 @@ internals.loadSeedData = callback => {
 describe('Dynogels Integration Tests', function () {
   this.timeout(0);
 
-  before(done => {
+  before((done) => {
     dynogels.dynamoDriver(helper.realDynamoDB());
 
     User = dynogels.define('dynogels-int-test-user', {
@@ -150,11 +151,11 @@ describe('Dynogels Integration Tests', function () {
 
     async.series([
       async.apply(dynogels.createTables.bind(dynogels)),
-      callback => {
+      (callback) => {
         const items = [{ fiz: 3, buz: 5, fizbuz: 35 }];
         User.create({ id: '123456789', email: 'some@user.com', age: 30, settings: { nickname: 'thedude' }, things: items }, callback);
       },
-      callback => {
+      (callback) => {
         User.create({ id: '9999', email: '9999@test.com', age: 99, name: 'Nancy Nine' }, callback);
       },
       internals.loadSeedData
@@ -162,7 +163,7 @@ describe('Dynogels Integration Tests', function () {
   });
 
   describe('#create', () => {
-    it('should create item with hash key', done => {
+    it('should create item with hash key', (done) => {
       User.create({
         email: 'foo@bar.com',
         age: 18,
@@ -180,7 +181,7 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should create item with empty string', done => {
+    it('should create item with empty string', (done) => {
       User.create({
         email: 'foo2@bar.com',
         name: '',
@@ -198,7 +199,7 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should return condition exception when using ConditionExpression', done => {
+    it('should return condition exception when using ConditionExpression', (done) => {
       const item = { email: 'test123@test.com', age: 33, roles: ['user'] };
 
       User.create(item, (err, acc) => {
@@ -222,7 +223,7 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should return condition exception when using expected shorthand', done => {
+    it('should return condition exception when using expected shorthand', (done) => {
       const item = { email: 'test444@test.com', age: 33, roles: ['user'] };
 
       User.create(item, (err, acc) => {
@@ -243,7 +244,7 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should return condition exception when using overwrite shorthand', done => {
+    it('should return condition exception when using overwrite shorthand', (done) => {
       const item = { email: 'testOverwrite@test.com', age: 20 };
 
       User.create(item, (err, acc) => {
@@ -261,7 +262,7 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should return custom errors specified in the schema', done => {
+    it('should return custom errors specified in the schema', (done) => {
       const item = { id: '123456789', email: 'newemail', custom: 'forbidden' };
       User.create(item, (err, acc) => {
         expect(err).to.exist;
@@ -271,7 +272,7 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should create item with dynamic keys', done => {
+    it('should create item with dynamic keys', (done) => {
       DynamicKeyModel.create({
         id: 'rand-1',
         name: 'Foo Bar',
@@ -285,7 +286,7 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should create multiple items at once', done => {
+    it('should create multiple items at once', (done) => {
       const item = { email: 'testMulti1@test.com', age: 10 };
       const item2 = { email: 'testMulti2@test.com', age: 20 };
       const item3 = { email: 'testMulti3@test.com', age: 30 };
@@ -301,7 +302,7 @@ describe('Dynogels Integration Tests', function () {
   });
 
   describe('#get', () => {
-    it('should get item by hash key', done => {
+    it('should get item by hash key', (done) => {
       User.get({ id: '123456789' }, (err, acc) => {
         expect(err).to.not.exist;
         expect(acc).to.exist;
@@ -310,7 +311,7 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should get return selected attributes AttributesToGet param', done => {
+    it('should get return selected attributes AttributesToGet param', (done) => {
       User.get({ id: '123456789' }, { AttributesToGet: ['email', 'age'] }, (err, acc) => {
         expect(err).to.not.exist;
         expect(acc).to.exist;
@@ -319,7 +320,7 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should get return selected attributes using ProjectionExpression param', done => {
+    it('should get return selected attributes using ProjectionExpression param', (done) => {
       User.get({ id: '123456789' }, { ProjectionExpression: 'email, age, settings.nickname' }, (err, acc) => {
         expect(err).to.not.exist;
         expect(acc).to.exist;
@@ -331,7 +332,7 @@ describe('Dynogels Integration Tests', function () {
   });
 
   describe('#update', () => {
-    it('should update item appended role', done => {
+    it('should update item appended role', (done) => {
       User.update({
         id: '123456789',
         roles: { $add: 'tester' }
@@ -377,7 +378,7 @@ describe('Dynogels Integration Tests', function () {
       );
     });
 
-    it('should remove name attribute from user record when set to empty string', done => {
+    it('should remove name attribute from user record when set to empty string', (done) => {
       User.update({ id: '9999', name: '' }, (err, acc) => {
         expect(err).to.not.exist;
         expect(acc).to.exist;
@@ -387,7 +388,7 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should update age using expected value', done => {
+    it('should update age using expected value', (done) => {
       User.update({ id: '9999', age: 100 }, { expected: { age: 99 } }, (err, acc) => {
         expect(err).to.not.exist;
         expect(acc).to.exist;
@@ -397,7 +398,7 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should update email using expected that an email already exists', done => {
+    it('should update email using expected that an email already exists', (done) => {
       User.update({ id: '9999', email: 'new9999@test.com' }, { expected: { email: { Exists: true } } }, (err, acc) => {
         expect(err).to.not.exist;
         expect(acc).to.exist;
@@ -407,7 +408,7 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should remove settings attribute from user record', done => {
+    it('should remove settings attribute from user record', (done) => {
       User.update({ id: '123456789', settings: null }, (err, acc) => {
         expect(err).to.not.exist;
         expect(acc).to.exist;
@@ -417,7 +418,7 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should update User using updateExpression', done => {
+    it('should update User using updateExpression', (done) => {
       const params = {};
       params.UpdateExpression = 'ADD #a :x SET things[0].buz = :y';
       params.ConditionExpression = '#a = :current';
@@ -433,7 +434,7 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should update Movie using updateExpressions', done => {
+    it('should update Movie using updateExpressions', (done) => {
       const params = {};
       params.UpdateExpression = 'SET #year = #year + :inc, #dir.titles = list_append(#dir.titles, :title), #act[0].firstName = :firstName ADD tags :tag';
       params.ConditionExpression = '#year = :current';
@@ -461,7 +462,7 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should update item with dynamic keys', done => {
+    it('should update item with dynamic keys', (done) => {
       DynamicKeyModel.update({
         id: 'rand-5',
         color: 'green',
@@ -538,7 +539,7 @@ describe('Dynogels Integration Tests', function () {
   });
 
   describe('#getItems', () => {
-    it('should return 3 items', done => {
+    it('should return 3 items', (done) => {
       User.getItems(['userid-1', 'userid-2', 'userid-3'], (err, accounts) => {
         expect(err).to.not.exist;
         expect(accounts).to.have.length(3);
@@ -546,13 +547,13 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should return 2 items with only selected attributes', done => {
+    it('should return 2 items with only selected attributes', (done) => {
       const opts = { AttributesToGet: ['email', 'age'] };
 
       User.getItems(['userid-1', 'userid-2'], opts, (err, accounts) => {
         expect(err).to.not.exist;
         expect(accounts).to.have.length(2);
-        _.each(accounts, acc => {
+        _.each(accounts, (acc) => {
           expect(acc.get()).to.have.keys(['email', 'age']);
         });
 
@@ -562,12 +563,12 @@ describe('Dynogels Integration Tests', function () {
   });
 
   describe('#query', () => {
-    it('should return users tweets', done => {
+    it('should return users tweets', (done) => {
       Tweet.query('userid-1').exec((err, data) => {
         expect(err).to.not.exist;
         expect(data.Items).to.have.length.above(0);
 
-        _.each(data.Items, t => {
+        _.each(data.Items, (t) => {
           expect(t.get('UserId')).to.eql('userid-1');
         });
 
@@ -575,12 +576,12 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should return users tweets with specific attributes', done => {
+    it('should return users tweets with specific attributes', (done) => {
       Tweet.query('userid-1').attributes(['num', 'content']).exec((err, data) => {
         expect(err).to.not.exist;
         expect(data.Items).to.have.length.above(0);
 
-        _.each(data.Items, t => {
+        _.each(data.Items, (t) => {
           expect(t.get('UserId')).to.not.exist;
           expect(t.get()).to.include.keys('num', 'content');
         });
@@ -589,87 +590,87 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should return tweets using secondaryIndex', done => {
+    it('should return tweets using secondaryIndex', (done) => {
       Tweet.query('userid-1')
-      .usingIndex('PublishedDateTimeIndex')
-      .consistentRead(true)
-      .descending()
-      .exec((err, data) => {
-        expect(err).to.not.exist;
-        expect(data.Items).to.have.length.above(0);
+        .usingIndex('PublishedDateTimeIndex')
+        .consistentRead(true)
+        .descending()
+        .exec((err, data) => {
+          expect(err).to.not.exist;
+          expect(data.Items).to.have.length.above(0);
 
-        let prev;
-        _.each(data.Items, t => {
-          expect(t.get('UserId')).to.eql('userid-1');
+          let prev;
+          _.each(data.Items, (t) => {
+            expect(t.get('UserId')).to.eql('userid-1');
 
-          const published = t.get('PublishedDateTime');
+            const published = t.get('PublishedDateTime');
 
-          if (prev) {
-            expect(published < prev).to.be.true;
-          }
+            if (prev) {
+              expect(published < prev).to.be.true;
+            }
 
-          prev = published;
+            prev = published;
+          });
+
+          return done();
         });
-
-        return done();
-      });
     });
 
-    it('should return tweets using secondaryIndex and date object', done => {
-      const oneMinAgo = new Date(new Date().getTime() - 60 * 1000);
+    it('should return tweets using secondaryIndex and date object', (done) => {
+      const oneMinAgo = new Date(new Date().getTime() - (60 * 1000));
 
       Tweet.query('userid-1')
-      .usingIndex('PublishedDateTimeIndex')
-      .where('PublishedDateTime').gt(oneMinAgo)
-      .descending()
-      .exec((err, data) => {
-        expect(err).to.not.exist;
-        expect(data.Items).to.have.length.above(0);
+        .usingIndex('PublishedDateTimeIndex')
+        .where('PublishedDateTime').gt(oneMinAgo)
+        .descending()
+        .exec((err, data) => {
+          expect(err).to.not.exist;
+          expect(data.Items).to.have.length.above(0);
 
-        let prev;
-        _.each(data.Items, t => {
-          expect(t.get('UserId')).to.eql('userid-1');
+          let prev;
+          _.each(data.Items, (t) => {
+            expect(t.get('UserId')).to.eql('userid-1');
 
-          const published = t.get('PublishedDateTime');
+            const published = t.get('PublishedDateTime');
 
-          if (prev) {
-            expect(published < prev).to.be.true;
-          }
+            if (prev) {
+              expect(published < prev).to.be.true;
+            }
 
-          prev = published;
+            prev = published;
+          });
+
+          return done();
         });
-
-        return done();
-      });
     });
 
-    it('should return tweets that match filters', done => {
+    it('should return tweets that match filters', (done) => {
       Tweet.query('userid-1')
-      .filter('num').between(4, 8)
-      .filter('tag').exists()
-      .exec((err, data) => {
-        expect(err).to.not.exist;
-        expect(data.Items).to.have.length.above(0);
+        .filter('num').between(4, 8)
+        .filter('tag').exists()
+        .exec((err, data) => {
+          expect(err).to.not.exist;
+          expect(data.Items).to.have.length.above(0);
 
-        _.each(data.Items, t => {
-          expect(t.get('UserId')).to.eql('userid-1');
-          expect(t.get('num')).to.be.above(3);
-          expect(t.get('num')).to.be.below(9);
-          expect(t.get('tag')).to.exist;
+          _.each(data.Items, (t) => {
+            expect(t.get('UserId')).to.eql('userid-1');
+            expect(t.get('num')).to.be.above(3);
+            expect(t.get('num')).to.be.below(9);
+            expect(t.get('tag')).to.exist;
+          });
+
+          return done();
         });
-
-        return done();
-      });
     });
 
-    it('should return tweets that match exists filter', done => {
+    it('should return tweets that match exists filter', (done) => {
       Tweet.query('userid-1')
         .filter('tag').exists()
         .exec((err, data) => {
           expect(err).to.not.exist;
           expect(data.Items).to.have.length.above(0);
 
-          _.each(data.Items, t => {
+          _.each(data.Items, (t) => {
             expect(t.get('UserId')).to.eql('userid-1');
             expect(t.get('tag')).to.exist;
           });
@@ -678,14 +679,14 @@ describe('Dynogels Integration Tests', function () {
         });
     });
 
-    it('should return tweets that match IN filter', done => {
+    it('should return tweets that match IN filter', (done) => {
       Tweet.query('userid-1')
         .filter('num').in([4, 6, 8])
         .exec((err, data) => {
           expect(err).to.not.exist;
           expect(data.Items).to.have.length.above(0);
 
-          _.each(data.Items, t => {
+          _.each(data.Items, (t) => {
             expect(t.get('UserId')).to.eql('userid-1');
             const c = _.includes([4, 6, 8], t.get('num'));
             expect(c).to.be.true;
@@ -695,48 +696,48 @@ describe('Dynogels Integration Tests', function () {
         });
     });
 
-    it('should return tweets that match expression filters', done => {
+    it('should return tweets that match expression filters', (done) => {
       Tweet.query('userid-1')
-      .filterExpression('#num BETWEEN :low AND :high AND attribute_exists(#tag)')
-      .expressionAttributeValues({ ':low': 4, ':high': 8 })
-      .expressionAttributeNames({ '#num': 'num', '#tag': 'tag' })
-      .exec((err, data) => {
-        expect(err).to.not.exist;
-        expect(data.Items).to.have.length.above(0);
+        .filterExpression('#num BETWEEN :low AND :high AND attribute_exists(#tag)')
+        .expressionAttributeValues({ ':low': 4, ':high': 8 })
+        .expressionAttributeNames({ '#num': 'num', '#tag': 'tag' })
+        .exec((err, data) => {
+          expect(err).to.not.exist;
+          expect(data.Items).to.have.length.above(0);
 
-        _.each(data.Items, t => {
-          expect(t.get('UserId')).to.eql('userid-1');
-          expect(t.get('num')).to.be.above(3);
-          expect(t.get('num')).to.be.below(9);
-          expect(t.get('tag')).to.exist;
+          _.each(data.Items, (t) => {
+            expect(t.get('UserId')).to.eql('userid-1');
+            expect(t.get('num')).to.be.above(3);
+            expect(t.get('num')).to.be.below(9);
+            expect(t.get('tag')).to.exist;
+          });
+
+          return done();
         });
-
-        return done();
-      });
     });
 
-    it('should return tweets with projection expression', done => {
+    it('should return tweets with projection expression', (done) => {
       Tweet.query('userid-1')
-      .projectionExpression('#con, UserId')
-      .expressionAttributeNames({ '#con': 'content' })
-      .exec((err, data) => {
-        expect(err).to.not.exist;
-        expect(data.Items).to.have.length.above(0);
+        .projectionExpression('#con, UserId')
+        .expressionAttributeNames({ '#con': 'content' })
+        .exec((err, data) => {
+          expect(err).to.not.exist;
+          expect(data.Items).to.have.length.above(0);
 
-        _.each(data.Items, t => {
-          expect(t.get()).to.have.keys(['content', 'UserId']);
+          _.each(data.Items, (t) => {
+            expect(t.get()).to.have.keys(['content', 'UserId']);
+          });
+
+          return done();
         });
-
-        return done();
-      });
     });
 
-    it('should return all tweets from user', done => {
+    it('should return all tweets from user', (done) => {
       Tweet.query('userid-1').limit(2).loadAll().exec((err, data) => {
         expect(err).to.not.exist;
         expect(data.Items).to.have.length.above(0);
 
-        _.each(data.Items, t => {
+        _.each(data.Items, (t) => {
           expect(t.get('UserId')).to.eql('userid-1');
         });
 
@@ -744,12 +745,12 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should return movie if directed by Steven Spielberg the 4', done => {
+    it('should return movie if directed by Steven Spielberg the 4', (done) => {
       Movie.query('Movie 4').filter('director.firstName').equals('Steven').filter('director.lastName').equals('Spielberg the 4').limit(2).loadAll().exec((err, data) => {
         expect(err).to.not.exist;
         expect(data.Items).to.have.length.above(0);
 
-        _.each(data.Items, t => {
+        _.each(data.Items, (t) => {
           expect(t.get('title')).to.eql('Movie 4');
 
           expect(t.get('director').firstName).to.eql('Steven');
@@ -763,7 +764,7 @@ describe('Dynogels Integration Tests', function () {
 
 
   describe('#scan', () => {
-    it('should return all users', done => {
+    it('should return all users', (done) => {
       User.scan().loadAll().exec((err, data) => {
         expect(err).to.not.exist;
         expect(data.Items).to.have.length.above(0);
@@ -772,7 +773,7 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should return all users with limit', done => {
+    it('should return all users with limit', (done) => {
       User.scan().limit(2).loadAll().exec((err, data) => {
         expect(err).to.not.exist;
         expect(data.Items).to.have.length.above(0);
@@ -781,13 +782,13 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should return users with specific attributes', done => {
+    it('should return users with specific attributes', (done) => {
       User.scan()
         .where('age').gt(18)
         .attributes(['email', 'roles', 'age']).exec((err, data) => {
           expect(err).to.not.exist;
           expect(data.Items).to.have.length.above(0);
-          _.each(data.Items, u => {
+          _.each(data.Items, (u) => {
             expect(u.get()).to.include.keys('email', 'roles', 'age');
           });
 
@@ -795,7 +796,7 @@ describe('Dynogels Integration Tests', function () {
         });
     });
 
-    it('should return 10 users', done => {
+    it('should return 10 users', (done) => {
       User.scan().limit(10).exec((err, data) => {
         expect(err).to.not.exist;
         expect(data.Items).to.have.length(10);
@@ -804,54 +805,54 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should return users older than 18', done => {
+    it('should return users older than 18', (done) => {
       User.scan()
-      .where('age').gt(18)
-      .exec((err, data) => {
-        expect(err).to.not.exist;
-        expect(data.Items).to.have.length.above(0);
+        .where('age').gt(18)
+        .exec((err, data) => {
+          expect(err).to.not.exist;
+          expect(data.Items).to.have.length.above(0);
 
-        _.each(data.Items, u => {
-          expect(u.get('age')).to.be.above(18);
+          _.each(data.Items, (u) => {
+            expect(u.get('age')).to.be.above(18);
+          });
+
+          return done();
         });
-
-        return done();
-      });
     });
 
-    it('should return users matching multiple filters', done => {
+    it('should return users matching multiple filters', (done) => {
       User.scan()
-      .where('age').between(18, 22)
-      .where('email').beginsWith('test1')
-      .exec((err, data) => {
-        expect(err).to.not.exist;
-        expect(data.Items).to.have.length.above(0);
+        .where('age').between(18, 22)
+        .where('email').beginsWith('test1')
+        .exec((err, data) => {
+          expect(err).to.not.exist;
+          expect(data.Items).to.have.length.above(0);
 
-        _.each(data.Items, u => {
-          expect(u.get('age')).to.be.within(18, 22);
-          expect(u.get('email')).to.match(/^test1.*/);
+          _.each(data.Items, (u) => {
+            expect(u.get('age')).to.be.within(18, 22);
+            expect(u.get('email')).to.match(/^test1.*/);
+          });
+
+          return done();
         });
-
-        return done();
-      });
     });
 
-    it('should return users contains admin role', done => {
+    it('should return users contains admin role', (done) => {
       User.scan()
-      .where('roles').contains('admin')
-      .exec((err, data) => {
-        expect(err).to.not.exist;
-        expect(data.Items).to.have.length.above(0);
+        .where('roles').contains('admin')
+        .exec((err, data) => {
+          expect(err).to.not.exist;
+          expect(data.Items).to.have.length.above(0);
 
-        _.each(data.Items, u => {
-          expect(u.get('roles')).to.include('admin');
+          _.each(data.Items, (u) => {
+            expect(u.get('roles')).to.include('admin');
+          });
+
+          return done();
         });
-
-        return done();
-      });
     });
 
-    it('should return users using stream interface', done => {
+    it('should return users using stream interface', (done) => {
       const stream = User.scan().exec();
 
       let called = false;
@@ -869,33 +870,16 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should return users that match expression filters', done => {
+    it('should return users that match expression filters', (done) => {
       User.scan()
-      .filterExpression('#age BETWEEN :low AND :high AND begins_with(#email, :e)')
-      .expressionAttributeValues({ ':low': 18, ':high': 22, ':e': 'test1' })
-      .expressionAttributeNames({ '#age': 'age', '#email': 'email' })
-      .exec((err, data) => {
-        expect(err).to.not.exist;
-        expect(data.Items).to.have.length.above(0);
-
-        _.each(data.Items, u => {
-          expect(u.get('age')).to.be.within(18, 22);
-          expect(u.get('email')).to.match(/^test1.*/);
-        });
-
-        return done();
-      });
-    });
-
-    it('should return users between ages', done => {
-      User.scan()
-        .where('age').between(18, 22)
-        .where('email').beginsWith('test1')
+        .filterExpression('#age BETWEEN :low AND :high AND begins_with(#email, :e)')
+        .expressionAttributeValues({ ':low': 18, ':high': 22, ':e': 'test1' })
+        .expressionAttributeNames({ '#age': 'age', '#email': 'email' })
         .exec((err, data) => {
           expect(err).to.not.exist;
           expect(data.Items).to.have.length.above(0);
 
-          _.each(data.Items, u => {
+          _.each(data.Items, (u) => {
             expect(u.get('age')).to.be.within(18, 22);
             expect(u.get('email')).to.match(/^test1.*/);
           });
@@ -904,14 +888,31 @@ describe('Dynogels Integration Tests', function () {
         });
     });
 
-    it('should return users matching IN filter', done => {
+    it('should return users between ages', (done) => {
+      User.scan()
+        .where('age').between(18, 22)
+        .where('email').beginsWith('test1')
+        .exec((err, data) => {
+          expect(err).to.not.exist;
+          expect(data.Items).to.have.length.above(0);
+
+          _.each(data.Items, (u) => {
+            expect(u.get('age')).to.be.within(18, 22);
+            expect(u.get('email')).to.match(/^test1.*/);
+          });
+
+          return done();
+        });
+    });
+
+    it('should return users matching IN filter', (done) => {
       User.scan()
         .where('age').in([2, 9, 20])
         .exec((err, data) => {
           expect(err).to.not.exist;
           expect(data.Items).to.have.length.above(0);
 
-          _.each(data.Items, u => {
+          _.each(data.Items, (u) => {
             const c = _.includes([2, 9, 20], u.get('age'));
             expect(c).to.be.true;
           });
@@ -920,23 +921,23 @@ describe('Dynogels Integration Tests', function () {
         });
     });
 
-    it('should return users with projection expression', done => {
+    it('should return users with projection expression', (done) => {
       User.scan()
-      .projectionExpression('age, email, #roles')
-      .expressionAttributeNames({ '#roles': 'roles' })
-      .exec((err, data) => {
-        expect(err).to.not.exist;
-        expect(data.Items).to.have.length.above(0);
+        .projectionExpression('age, email, #roles')
+        .expressionAttributeNames({ '#roles': 'roles' })
+        .exec((err, data) => {
+          expect(err).to.not.exist;
+          expect(data.Items).to.have.length.above(0);
 
-        _.each(data.Items, u => {
-          expect(u.get()).to.have.keys(['age', 'email', 'roles']);
+          _.each(data.Items, (u) => {
+            expect(u.get()).to.have.keys(['age', 'email', 'roles']);
+          });
+
+          return done();
         });
-
-        return done();
-      });
     });
 
-    it('should load all users with limit', done => {
+    it('should load all users with limit', (done) => {
       User.scan().loadAll().limit(2).exec((err, data) => {
         expect(err).to.not.exist;
         expect(data.Items).to.have.length.above(0);
@@ -945,7 +946,7 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should return users using stream interface and limit', done => {
+    it('should return users using stream interface and limit', (done) => {
       const stream = User.scan().loadAll().limit(2).exec();
 
       let called = false;
@@ -964,12 +965,12 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should load tweets using not null tag clause', done => {
+    it('should load tweets using not null tag clause', (done) => {
       Tweet.scan().where('tag').notNull().exec((err, data) => {
         expect(err).to.not.exist;
         expect(data.Items).to.have.length.above(0);
 
-        _.each(data.Items, t => {
+        _.each(data.Items, (t) => {
           expect(t.get('tag')).to.exist;
         });
 
@@ -977,12 +978,12 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should return all movies directed by Steven Spielberg the 4', done => {
+    it('should return all movies directed by Steven Spielberg the 4', (done) => {
       Movie.scan().where('director.firstName').equals('Steven').where('director.lastName').equals('Spielberg the 4').limit(2).loadAll().exec((err, data) => {
         expect(err).to.not.exist;
         expect(data.Items).to.have.length.above(0);
 
-        _.each(data.Items, t => {
+        _.each(data.Items, (t) => {
           expect(t.get('director').firstName).to.eql('Steven');
           expect(t.get('director').lastName).to.eql('Spielberg the 4');
         });
@@ -993,7 +994,7 @@ describe('Dynogels Integration Tests', function () {
   });
 
   describe('#parallelScan', () => {
-    it('should return all users', done => {
+    it('should return all users', (done) => {
       User.parallelScan(4).exec((err, data) => {
         expect(err).to.not.exist;
         expect(data.Items).to.have.length.above(0);
@@ -1002,22 +1003,22 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should return users older than 18', done => {
+    it('should return users older than 18', (done) => {
       User.parallelScan(4)
-      .where('age').gt(18)
-      .exec((err, data) => {
-        expect(err).to.not.exist;
-        expect(data.Items).to.have.length.above(0);
+        .where('age').gt(18)
+        .exec((err, data) => {
+          expect(err).to.not.exist;
+          expect(data.Items).to.have.length.above(0);
 
-        _.each(data.Items, u => {
-          expect(u.get('age')).to.be.above(18);
+          _.each(data.Items, (u) => {
+            expect(u.get('age')).to.be.above(18);
+          });
+
+          return done();
         });
-
-        return done();
-      });
     });
 
-    it('should return users using stream interface', done => {
+    it('should return users using stream interface', (done) => {
       const stream = User.parallelScan(4).exec();
 
       let called = false;
@@ -1042,7 +1043,7 @@ describe('Dynogels Integration Tests', function () {
     let Model;
     let ModelCustomTimestamps;
 
-    before(done => {
+    before((done) => {
       Model = dynogels.define('dynogels-int-test-timestamp', {
         hashKey: 'id',
         timestamps: true,
@@ -1065,8 +1066,8 @@ describe('Dynogels Integration Tests', function () {
       return dynogels.createTables(done);
     });
 
-    it('should add createdAt param', done => {
-      Model.create({ id: 'test-1' }, err => {
+    it('should add createdAt param', (done) => {
+      Model.create({ id: 'test-1' }, (err) => {
         expect(err).to.not.exist;
 
         Model.get('test-1', (err2, data) => {
@@ -1080,8 +1081,8 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should add updatedAt param', done => {
-      Model.update({ id: 'test-2' }, err => {
+    it('should add updatedAt param', (done) => {
+      Model.update({ id: 'test-2' }, (err) => {
         expect(err).to.not.exist;
 
         Model.get('test-2', (err2, data) => {
@@ -1095,8 +1096,8 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should add custom createdAt param', done => {
-      ModelCustomTimestamps.create({ id: 'test-1' }, err => {
+    it('should add custom createdAt param', (done) => {
+      ModelCustomTimestamps.create({ id: 'test-1' }, (err) => {
         expect(err).to.not.exist;
 
         ModelCustomTimestamps.get('test-1', (err2, data) => {
@@ -1110,8 +1111,8 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should add custom updatedAt param', done => {
-      ModelCustomTimestamps.update({ id: 'test-2' }, err => {
+    it('should add custom updatedAt param', (done) => {
+      ModelCustomTimestamps.update({ id: 'test-2' }, (err) => {
         expect(err).to.not.exist;
 
         ModelCustomTimestamps.get('test-2', (err2, data) => {
@@ -1128,7 +1129,7 @@ describe('Dynogels Integration Tests', function () {
 
   describe('#destroy', () => {
     let userId;
-    beforeEach(done => {
+    beforeEach((done) => {
       User.create({ email: 'destroy@test.com', age: 20, roles: ['tester'] }, (err, acc) => {
         expect(err).to.not.exist;
         userId = acc.get('id');
@@ -1137,14 +1138,14 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should destroy item with hash key', done => {
-      User.destroy({ id: userId }, err => {
+    it('should destroy item with hash key', (done) => {
+      User.destroy({ id: userId }, (err) => {
         expect(err).to.not.exist;
         return done();
       });
     });
 
-    it('should destroy item and return old values', done => {
+    it('should destroy item and return old values', (done) => {
       User.destroy({ id: userId }, { ReturnValues: 'ALL_OLD' }, (err, acc) => {
         expect(err).to.not.exist;
         expect(acc).to.exist;
@@ -1153,7 +1154,7 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should return condition exception when using ConditionExpression', done => {
+    it('should return condition exception when using ConditionExpression', (done) => {
       const params = {};
       params.ConditionExpression = '#i = :x';
       params.ExpressionAttributeNames = { '#i': 'id' };
@@ -1168,7 +1169,7 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('should return condition exception when using Expected shorthand', done => {
+    it('should return condition exception when using Expected shorthand', (done) => {
       const opts = { expected: { id: 'dontexist' } };
 
       User.destroy({ id: 'dontexist' }, opts, (err, acc) => {
@@ -1183,32 +1184,32 @@ describe('Dynogels Integration Tests', function () {
 
 
   describe('model methods', () => {
-    it('#save with passed in attributes', done => {
+    it('#save with passed in attributes', (done) => {
       const t = new Tweet({
         UserId: 'tester-1',
         content: 'save test tweet',
         tag: 'test'
       });
 
-      t.save(err => {
+      t.save((err) => {
         expect(err).to.not.exist;
         return done();
       });
     });
 
-    it('#save without passed in attributes', done => {
+    it('#save without passed in attributes', (done) => {
       const t = new Tweet();
 
       const attrs = { UserId: 'tester-1', content: 'save test tweet', tag: 'test' };
       t.set(attrs);
 
-      t.save(err => {
+      t.save((err) => {
         expect(err).to.not.exist;
         return done();
       });
     });
 
-    it('#save without callback', done => {
+    it('#save without callback', (done) => {
       const t = new Tweet({
         UserId: 'tester-1',
         content: 'save test tweet',
@@ -1220,13 +1221,13 @@ describe('Dynogels Integration Tests', function () {
       return done();
     });
 
-    it('#update with callback', done => {
+    it('#update with callback', (done) => {
       Tweet.create({ UserId: 'tester-2', content: 'update test tweet' }, (err, tweet) => {
         expect(err).to.not.exist;
 
         tweet.set({ tag: 'update' });
 
-        tweet.update(err => {
+        tweet.update((err) => {
           expect(err).to.not.exist;
           expect(tweet.get('tag')).to.eql('update');
           return done();
@@ -1234,7 +1235,7 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('#update without callback', done => {
+    it('#update without callback', (done) => {
       Tweet.create({ UserId: 'tester-2', content: 'update test tweet' }, (err, tweet) => {
         expect(err).to.not.exist;
 
@@ -1247,18 +1248,18 @@ describe('Dynogels Integration Tests', function () {
     });
 
 
-    it('#destroy with callback', done => {
+    it('#destroy with callback', (done) => {
       Tweet.create({ UserId: 'tester-2', content: 'update test tweet' }, (err, tweet) => {
         expect(err).to.not.exist;
 
-        tweet.destroy(err => {
+        tweet.destroy((err) => {
           expect(err).to.not.exist;
           return done();
         });
       });
     });
 
-    it('#destroy without callback', done => {
+    it('#destroy without callback', (done) => {
       Tweet.create({ UserId: 'tester-2', content: 'update test tweet' }, (err, tweet) => {
         expect(err).to.not.exist;
 
@@ -1268,7 +1269,7 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('#toJSON', done => {
+    it('#toJSON', (done) => {
       Tweet.create({ UserId: 'tester-2', content: 'update test tweet' }, (err, tweet) => {
         expect(err).to.not.exist;
 
@@ -1277,7 +1278,7 @@ describe('Dynogels Integration Tests', function () {
       });
     });
 
-    it('#toPlainObject', done => {
+    it('#toPlainObject', (done) => {
       Tweet.create({ UserId: 'tester-2', content: 'update test tweet' }, (err, tweet) => {
         expect(err).to.not.exist;
 

--- a/test/item-test.js
+++ b/test/item-test.js
@@ -4,10 +4,11 @@ const Item = require('../lib/item');
 const Table = require('../lib/table');
 const Schema = require('../lib/schema');
 const chai = require('chai');
-const expect = chai.expect;
 const helper = require('./test-helper');
 const serializer = require('../lib/serializer');
 const Joi = require('joi');
+
+const expect = chai.expect;
 
 chai.should();
 
@@ -37,7 +38,7 @@ describe('item', () => {
   });
 
   describe('#save', () => {
-    it('should return error', done => {
+    it('should return error', (done) => {
       table.docClient.put.yields(new Error('fail'));
 
       const attrs = { num: 1, name: 'foo' };
@@ -53,7 +54,7 @@ describe('item', () => {
   });
 
   describe('#update', () => {
-    it('should return item', done => {
+    it('should return item', (done) => {
       table.docClient.update.yields(null, { Attributes: { num: 1, name: 'foo' } });
 
       const attrs = { num: 1, name: 'foo' };
@@ -68,7 +69,7 @@ describe('item', () => {
     });
 
 
-    it('should return error', done => {
+    it('should return error', (done) => {
       table.docClient.update.yields(new Error('fail'));
 
       const attrs = { num: 1, name: 'foo' };
@@ -82,7 +83,7 @@ describe('item', () => {
       });
     });
 
-    it('should return null', done => {
+    it('should return null', (done) => {
       table.docClient.update.yields(null, {});
 
       const attrs = { num: 1, name: 'foo' };

--- a/test/parallel-test.js
+++ b/test/parallel-test.js
@@ -4,11 +4,12 @@ const Table = require('../lib/table');
 const ParallelScan = require('../lib/parallelScan');
 const Schema = require('../lib/schema');
 const chai = require('chai');
-const expect = chai.expect;
 const assert = require('assert');
 const helper = require('./test-helper');
 const serializer = require('../lib/serializer');
 const Joi = require('joi');
+
+const expect = chai.expect;
 
 chai.should();
 
@@ -29,7 +30,7 @@ describe('ParallelScan', () => {
     table = new Table('mockTable', schema, serializer, helper.mockDynamoDB(), helper.testLogger());
   });
 
-  it('should return error', done => {
+  it('should return error', (done) => {
     const scan = new ParallelScan(table, serializer, 4);
 
     table.docClient.scan.yields(new Error('fail'));
@@ -42,14 +43,14 @@ describe('ParallelScan', () => {
     });
   });
 
-  it('should stream error', done => {
+  it('should stream error', (done) => {
     const scan = new ParallelScan(table, serializer, 4);
 
     table.docClient.scan.yields(new Error('fail'));
 
     const stream = scan.exec();
 
-    stream.on('error', err => {
+    stream.on('error', (err) => {
       expect(err).to.exist;
       return done();
     });

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -6,9 +6,10 @@ const Query = require('../lib//query');
 const Serializer = require('../lib/serializer');
 const Table = require('../lib/table');
 const chai = require('chai');
-const expect = chai.expect;
 const assert = require('assert');
 const Joi = require('joi');
+
+const expect = chai.expect;
 
 chai.should();
 
@@ -25,7 +26,7 @@ describe('Query', () => {
   });
 
   describe('#exec', () => {
-    it('should run query against table', done => {
+    it('should run query against table', (done) => {
       const config = {
         hashKey: 'name',
         rangeKey: 'email',
@@ -46,7 +47,7 @@ describe('Query', () => {
       });
     });
 
-    it('should return error', done => {
+    it('should return error', (done) => {
       const config = {
         hashKey: 'name',
         rangeKey: 'email',
@@ -68,7 +69,7 @@ describe('Query', () => {
       });
     });
 
-    it('should stream error', done => {
+    it('should stream error', (done) => {
       const config = {
         hashKey: 'name',
         rangeKey: 'email',
@@ -86,7 +87,7 @@ describe('Query', () => {
 
       const stream = new Query('tim', t, Serializer).exec();
 
-      stream.on('error', err => {
+      stream.on('error', (err) => {
         expect(err).to.exist;
         return done();
       });
@@ -96,7 +97,7 @@ describe('Query', () => {
       });
     });
 
-    it('should stream data after handling retryable error', done => {
+    it('should stream data after handling retryable error', (done) => {
       const config = {
         hashKey: 'name',
         rangeKey: 'email',

--- a/test/scan-test.js
+++ b/test/scan-test.js
@@ -5,8 +5,9 @@ const Schema = require('../lib/schema');
 const Scan = require('../lib/scan');
 const _ = require('lodash');
 const chai = require('chai');
-const expect = chai.expect;
 const Joi = require('joi');
+
+const expect = chai.expect;
 
 chai.should();
 
@@ -51,7 +52,7 @@ describe('Scan', () => {
   });
 
   describe('#exec', () => {
-    it('should call run scan on table', done => {
+    it('should call run scan on table', (done) => {
       table.runScan.yields(null, { ConsumedCapacity: { CapacityUnits: 5, TableName: 'accounts' }, Count: 10, ScannedCount: 12 });
       serializer.serializeItem.returns({ name: { S: 'tim' } });
 
@@ -64,7 +65,7 @@ describe('Scan', () => {
       });
     });
 
-    it('should return LastEvaluatedKey', done => {
+    it('should return LastEvaluatedKey', (done) => {
       table.runScan.yields(null, { LastEvaluatedKey: { name: 'tim' }, Count: 10, ScannedCount: 12 });
       serializer.serializeItem.returns({ name: { S: 'tim' } });
 
@@ -78,7 +79,7 @@ describe('Scan', () => {
       });
     });
 
-    it('should return error', done => {
+    it('should return error', (done) => {
       table.runScan.yields(new Error('Fail'));
 
       new Scan(table, serializer).exec((err, results) => {
@@ -88,7 +89,7 @@ describe('Scan', () => {
       });
     });
 
-    it('should run scan after encountering a retryable exception', done => {
+    it('should run scan after encountering a retryable exception', (done) => {
       const err = new Error('RetryableException');
       err.retryable = true;
 

--- a/test/schema-test.js
+++ b/test/schema-test.js
@@ -2,10 +2,11 @@
 
 const Schema = require('../lib/schema');
 const chai = require('chai');
-const expect = chai.expect;
 const Joi = require('joi');
 const _ = require('lodash');
 const sinon = require('sinon');
+
+const expect = chai.expect;
 
 chai.should();
 

--- a/test/serializer-test.js
+++ b/test/serializer-test.js
@@ -2,10 +2,11 @@
 
 const serializer = require('../lib/serializer');
 const chai = require('chai');
-const expect = chai.expect;
 const Schema = require('../lib/schema');
 const helper = require('./test-helper');
 const Joi = require('joi');
+
+const expect = chai.expect;
 
 chai.should();
 
@@ -222,9 +223,9 @@ describe('Serializer', () => {
 
       const s = new Schema(config);
 
-      const item = serializer.serializeItem(s, { data: 'hello', bin: new Buffer('binary') });
+      const item = serializer.serializeItem(s, { data: 'hello', bin: Buffer.from('binary') });
 
-      item.should.eql({ data: new Buffer('hello'), bin: new Buffer('binary') });
+      item.should.eql({ data: Buffer.from('hello'), bin: Buffer.from('binary') });
     });
 
     it('should serialize number attribute with value zero', () => {
@@ -367,7 +368,7 @@ describe('Serializer', () => {
 
       const item = serializer.serializeItem(s, { data: ['hello', 'world'] });
 
-      const binarySet = docClient.createSet([new Buffer('hello'), new Buffer('world')]);
+      const binarySet = docClient.createSet([Buffer.from('hello'), Buffer.from('world')]);
       item.data.type.should.eql('Binary');
       item.data.values.should.eql(binarySet.values);
     });
@@ -385,7 +386,7 @@ describe('Serializer', () => {
 
       const item = serializer.serializeItem(s, { data: 'hello' });
 
-      const binarySet = docClient.createSet([new Buffer('hello')]);
+      const binarySet = docClient.createSet([Buffer.from('hello')]);
       item.data.type.should.eql('Binary');
       item.data.values.should.eql(binarySet.values);
     });

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -10,8 +10,9 @@ const Scan = require('../lib//scan');
 const Item = require('../lib/item');
 const realSerializer = require('../lib/serializer');
 const chai = require('chai');
-const expect = chai.expect;
 const sinon = require('sinon');
+
+const expect = chai.expect;
 
 chai.should();
 
@@ -30,7 +31,7 @@ describe('table', () => {
   });
 
   describe('#get', () => {
-    it('should get item by hash key', done => {
+    it('should get item by hash key', (done) => {
       const config = {
         hashKey: 'email'
       };
@@ -59,7 +60,7 @@ describe('table', () => {
       });
     });
 
-    it('should get item by hash and range key', done => {
+    it('should get item by hash and range key', (done) => {
       const config = {
         hashKey: 'name',
         rangeKey: 'email'
@@ -92,7 +93,7 @@ describe('table', () => {
       });
     });
 
-    it('should get item by hash key and options', done => {
+    it('should get item by hash key and options', (done) => {
       const config = {
         hashKey: 'email',
       };
@@ -122,7 +123,7 @@ describe('table', () => {
       });
     });
 
-    it('should get item by hashkey, range key and options', done => {
+    it('should get item by hashkey, range key and options', (done) => {
       const config = {
         hashKey: 'name',
         rangeKey: 'email',
@@ -156,7 +157,7 @@ describe('table', () => {
       });
     });
 
-    it('should get item from dynamic table by hash key', done => {
+    it('should get item from dynamic table by hash key', (done) => {
       const config = {
         hashKey: 'email',
         tableName: function () {
@@ -188,7 +189,7 @@ describe('table', () => {
       });
     });
 
-    it('should return error', done => {
+    it('should return error', (done) => {
       const config = {
         hashKey: 'email',
       };
@@ -208,7 +209,7 @@ describe('table', () => {
   });
 
   describe('#create', () => {
-    it('should create valid item', done => {
+    it('should create valid item', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -244,7 +245,7 @@ describe('table', () => {
       });
     });
 
-    it('should call apply defaults', done => {
+    it('should call apply defaults', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -280,7 +281,7 @@ describe('table', () => {
       });
     });
 
-    it('should omit null values', done => {
+    it('should omit null values', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -296,7 +297,7 @@ describe('table', () => {
 
       table = new Table('accounts', s, realSerializer, docClient, logger);
 
-      const numberSet = sinon.match(value => {
+      const numberSet = sinon.match((value) => {
         const s = docClient.createSet([1, 2, 3]);
 
         value.type.should.eql('Number');
@@ -330,7 +331,7 @@ describe('table', () => {
       });
     });
 
-    it('should omit empty values', done => {
+    it('should omit empty values', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -365,7 +366,7 @@ describe('table', () => {
       });
     });
 
-    it('should create item with createdAt timestamp', done => {
+    it('should create item with createdAt timestamp', (done) => {
       const config = {
         hashKey: 'email',
         timestamps: true,
@@ -398,7 +399,7 @@ describe('table', () => {
       });
     });
 
-    it('should create item with custom createdAt attribute name', done => {
+    it('should create item with custom createdAt attribute name', (done) => {
       const config = {
         hashKey: 'email',
         timestamps: true,
@@ -433,7 +434,7 @@ describe('table', () => {
     });
 
 
-    it('should create item without createdAt param', done => {
+    it('should create item without createdAt param', (done) => {
       const config = {
         hashKey: 'email',
         timestamps: true,
@@ -466,7 +467,7 @@ describe('table', () => {
       });
     });
 
-    it('should create item with expected option', done => {
+    it('should create item with expected option', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -500,7 +501,7 @@ describe('table', () => {
       });
     });
 
-    it('should create item with no callback', done => {
+    it('should create item with no callback', (done) => {
       const config = {
         hashKey: 'email',
         timestamps: true,
@@ -528,7 +529,7 @@ describe('table', () => {
       return done();
     });
 
-    it('should return validation error', done => {
+    it('should return validation error', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -551,7 +552,7 @@ describe('table', () => {
       });
     });
 
-    it('should fail with custom errors specified in schema', done => {
+    it('should fail with custom errors specified in schema', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -574,7 +575,7 @@ describe('table', () => {
       });
     });
 
-    it('should create item with condition expression on hashkey when overwrite flag is false', done => {
+    it('should create item with condition expression on hashkey when overwrite flag is false', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -609,7 +610,7 @@ describe('table', () => {
       });
     });
 
-    it('should create item with condition expression on hash and range key when overwrite flag is false', done => {
+    it('should create item with condition expression on hash and range key when overwrite flag is false', (done) => {
       const config = {
         hashKey: 'email',
         rangeKey: 'name',
@@ -645,7 +646,7 @@ describe('table', () => {
       });
     });
 
-    it('should create item without condition expression when overwrite flag is true', done => {
+    it('should create item without condition expression when overwrite flag is true', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -679,7 +680,7 @@ describe('table', () => {
   });
 
   describe('#update', () => {
-    it('should update valid item', done => {
+    it('should update valid item', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -724,7 +725,7 @@ describe('table', () => {
       });
     });
 
-    it('should accept falsy key and range values', done => {
+    it('should accept falsy key and range values', (done) => {
       const config = {
         hashKey: 'userId',
         rangeKey: 'timeOffset',
@@ -761,7 +762,7 @@ describe('table', () => {
       });
     });
 
-    it('should update with passed in options', done => {
+    it('should update with passed in options', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -816,7 +817,7 @@ describe('table', () => {
       });
     });
 
-    it('should update merge update expressions when passed in as options', done => {
+    it('should update merge update expressions when passed in as options', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -870,7 +871,7 @@ describe('table', () => {
       });
     });
 
-    it('should update valid item without a callback', done => {
+    it('should update valid item without a callback', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -909,7 +910,7 @@ describe('table', () => {
       return done();
     });
 
-    it('should return error', done => {
+    it('should return error', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -996,7 +997,7 @@ describe('table', () => {
   });
 
   describe('#destroy', () => {
-    it('should destroy valid item', done => {
+    it('should destroy valid item', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -1029,7 +1030,7 @@ describe('table', () => {
       });
     });
 
-    it('should destroy valid item with falsy hash and range keys', done => {
+    it('should destroy valid item with falsy hash and range keys', (done) => {
       const config = {
         hashKey: 'userId',
         rangeKey: 'timeOffset',
@@ -1063,7 +1064,7 @@ describe('table', () => {
       });
     });
 
-    it('should take optional params', done => {
+    it('should take optional params', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -1097,7 +1098,7 @@ describe('table', () => {
       });
     });
 
-    it('should parse and return attributes', done => {
+    it('should parse and return attributes', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -1125,9 +1126,10 @@ describe('table', () => {
       docClient.delete.yields(null, { Attributes: returnedAttributes });
 
       serializer.buildKey.returns(request.Key);
-      serializer.deserializeItem.withArgs(returnedAttributes).returns(
-        { email: 'test@test.com', name: 'Foo Bar'
-        });
+      serializer
+        .deserializeItem
+        .withArgs(returnedAttributes)
+        .returns({ email: 'test@test.com', name: 'Foo Bar' });
 
       table.destroy('test@test.com', { ReturnValues: 'ALL_OLD' }, (err, item) => {
         serializer.buildKey.calledWith('test@test.com', null, s).should.be.true;
@@ -1139,7 +1141,7 @@ describe('table', () => {
       });
     });
 
-    it('should accept hash and range key', done => {
+    it('should accept hash and range key', (done) => {
       const config = {
         hashKey: 'email',
         rangeKey: 'name',
@@ -1170,9 +1172,10 @@ describe('table', () => {
       docClient.delete.yields(null, { Attributes: returnedAttributes });
 
       serializer.buildKey.returns(request.Key);
-      serializer.deserializeItem.withArgs(returnedAttributes).returns(
-        { email: 'test@test.com', name: 'Foo Bar'
-        });
+      serializer
+        .deserializeItem
+        .withArgs(returnedAttributes)
+        .returns({ email: 'test@test.com', name: 'Foo Bar' });
 
       table.destroy('test@test.com', 'Foo Bar', (err, item) => {
         serializer.buildKey.calledWith('test@test.com', 'Foo Bar', s).should.be.true;
@@ -1184,7 +1187,7 @@ describe('table', () => {
       });
     });
 
-    it('should accept hashkey rangekey and options', done => {
+    it('should accept hashkey rangekey and options', (done) => {
       const config = {
         hashKey: 'email',
         rangeKey: 'name',
@@ -1216,9 +1219,10 @@ describe('table', () => {
       docClient.delete.yields(null, { Attributes: returnedAttributes });
 
       serializer.buildKey.returns(request.Key);
-      serializer.deserializeItem.withArgs(returnedAttributes).returns(
-        { email: 'test@test.com', name: 'Foo Bar'
-        });
+      serializer
+        .deserializeItem
+        .withArgs(returnedAttributes)
+        .returns({ email: 'test@test.com', name: 'Foo Bar' });
 
       table.destroy('test@test.com', 'Foo Bar', { ReturnValues: 'ALL_OLD' }, (err, item) => {
         serializer.buildKey.calledWith('test@test.com', 'Foo Bar', s).should.be.true;
@@ -1230,7 +1234,7 @@ describe('table', () => {
       });
     });
 
-    it('should serialize expected option', done => {
+    it('should serialize expected option', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -1267,7 +1271,7 @@ describe('table', () => {
       });
     });
 
-    it('should call delete item without callback', done => {
+    it('should call delete item without callback', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -1296,7 +1300,7 @@ describe('table', () => {
       return done();
     });
 
-    it('should call delete item with hash key, options and no callback', done => {
+    it('should call delete item with hash key, options and no callback', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -1330,7 +1334,7 @@ describe('table', () => {
   });
 
   describe('#describeTable', () => {
-    it('should make describe table request', done => {
+    it('should make describe table request', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -1349,7 +1353,7 @@ describe('table', () => {
 
       dynamodb.describeTable.yields(null, {});
 
-      table.describeTable(err => {
+      table.describeTable((err) => {
         expect(err).to.be.null;
         dynamodb.describeTable.calledWith(request).should.be.true;
         done();
@@ -1372,7 +1376,7 @@ describe('table', () => {
       table = new Table('accounts', s, serializer, docClient, logger);
     });
 
-    it('should make update table request', done => {
+    it('should make update table request', (done) => {
       const request = {
         TableName: 'accounts',
         ProvisionedThroughput: { ReadCapacityUnits: 4, WriteCapacityUnits: 2 }
@@ -1381,14 +1385,14 @@ describe('table', () => {
       dynamodb.describeTable.yields(null, {});
       dynamodb.updateTable.yields(null, {});
 
-      table.updateTable({ readCapacity: 4, writeCapacity: 2 }, err => {
+      table.updateTable({ readCapacity: 4, writeCapacity: 2 }, (err) => {
         expect(err).to.be.null;
         dynamodb.updateTable.calledWith(request).should.be.true;
         done();
       });
     });
 
-    it('should make update table request without callback', done => {
+    it('should make update table request without callback', (done) => {
       const request = {
         TableName: 'accounts',
         ProvisionedThroughput: { ReadCapacityUnits: 2, WriteCapacityUnits: 1 }
@@ -1417,21 +1421,21 @@ describe('table', () => {
       table = new Table('accounts', s, serializer, docClient, logger);
     });
 
-    it('should make delete table request', done => {
+    it('should make delete table request', (done) => {
       const request = {
         TableName: 'accounts'
       };
 
       dynamodb.deleteTable.yields(null, {});
 
-      table.deleteTable(err => {
+      table.deleteTable((err) => {
         expect(err).to.be.null;
         dynamodb.deleteTable.calledWith(request).should.be.true;
         done();
       });
     });
 
-    it('should make delete table request without callback', done => {
+    it('should make delete table request without callback', (done) => {
       const request = {
         TableName: 'accounts',
       };
@@ -1730,7 +1734,7 @@ describe('table', () => {
   });
 
   describe('#createTable', () => {
-    it('should call dynamo.createTable with the dynamoCreateTableParams result', done => {
+    it('should call dynamo.createTable with the dynamoCreateTableParams result', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -1751,7 +1755,7 @@ describe('table', () => {
 
       dynamodb.createTable.yields(null, {});
 
-      table.createTable(options, err => {
+      table.createTable(options, (err) => {
         expect(err).to.be.null;
         dynamoCreateTableParamsStub.calledOnce.should.be.true;
         expect(dynamoCreateTableParamsStub.args[0]).to.deep.equal([options]);
@@ -1764,7 +1768,7 @@ describe('table', () => {
   });
 
   describe('#describeTable', () => {
-    it('should make describe table request', done => {
+    it('should make describe table request', (done) => {
       const config = {
         hashKey: 'email',
         schema: {
@@ -1783,7 +1787,7 @@ describe('table', () => {
 
       dynamodb.describeTable.yields(null, {});
 
-      table.describeTable(err => {
+      table.describeTable((err) => {
         expect(err).to.be.null;
         dynamodb.describeTable.calledWith(request).should.be.true;
         done();
@@ -1806,7 +1810,7 @@ describe('table', () => {
       table = new Table('accounts', s, serializer, docClient, logger);
     });
 
-    it('should make update table request', done => {
+    it('should make update table request', (done) => {
       const request = {
         TableName: 'accounts',
         ProvisionedThroughput: { ReadCapacityUnits: 4, WriteCapacityUnits: 2 }
@@ -1815,14 +1819,14 @@ describe('table', () => {
       dynamodb.describeTable.yields(null, {});
       dynamodb.updateTable.yields(null, {});
 
-      table.updateTable({ readCapacity: 4, writeCapacity: 2 }, err => {
+      table.updateTable({ readCapacity: 4, writeCapacity: 2 }, (err) => {
         expect(err).to.be.null;
         dynamodb.updateTable.calledWith(request).should.be.true;
         done();
       });
     });
 
-    it('should make update table request without callback', done => {
+    it('should make update table request without callback', (done) => {
       const request = {
         TableName: 'accounts',
         ProvisionedThroughput: { ReadCapacityUnits: 2, WriteCapacityUnits: 1 }
@@ -1851,21 +1855,21 @@ describe('table', () => {
       table = new Table('accounts', s, serializer, docClient, logger);
     });
 
-    it('should make delete table request', done => {
+    it('should make delete table request', (done) => {
       const request = {
         TableName: 'accounts'
       };
 
       dynamodb.deleteTable.yields(null, {});
 
-      table.deleteTable(err => {
+      table.deleteTable((err) => {
         expect(err).to.be.null;
         dynamodb.deleteTable.calledWith(request).should.be.true;
         done();
       });
     });
 
-    it('should make delete table request without callback', done => {
+    it('should make delete table request without callback', (done) => {
       const request = {
         TableName: 'accounts',
       };
@@ -1937,7 +1941,7 @@ describe('table', () => {
 
   describe('hooks', () => {
     describe('#create', () => {
-      it('should call before hooks', done => {
+      it('should call before hooks', (done) => {
         const config = {
           hashKey: 'email',
           schema: {
@@ -1979,7 +1983,7 @@ describe('table', () => {
         });
       });
 
-      it('should return error when before hook returns error', done => {
+      it('should return error when before hook returns error', (done) => {
         const config = {
           hashKey: 'email',
           schema: {
@@ -2003,7 +2007,7 @@ describe('table', () => {
         });
       });
 
-      it('should call after hook', done => {
+      it('should call after hook', (done) => {
         const config = {
           hashKey: 'email',
           schema: {
@@ -2022,7 +2026,7 @@ describe('table', () => {
 
         serializer.serializeItem.withArgs(s, item).returns({});
 
-        table.after('create', data => {
+        table.after('create', (data) => {
           expect(data).to.exist;
 
           return done();
@@ -2033,7 +2037,7 @@ describe('table', () => {
     });
 
     describe('#update', () => {
-      it('should call before hook', done => {
+      it('should call before hook', (done) => {
         const config = {
           hashKey: 'email',
           schema: {
@@ -2074,7 +2078,7 @@ describe('table', () => {
         table.update(item, () => {});
       });
 
-      it('should return error when before hook returns error', done => {
+      it('should return error when before hook returns error', (done) => {
         const config = {
           hashKey: 'email',
           schema: {
@@ -2090,7 +2094,7 @@ describe('table', () => {
 
         table.before('update', (data, next) => next(new Error('fail')));
 
-        table.update({}, err => {
+        table.update({}, (err) => {
           expect(err).to.exist;
           err.message.should.equal('fail');
 
@@ -2098,7 +2102,7 @@ describe('table', () => {
         });
       });
 
-      it('should call after hook', done => {
+      it('should call after hook', (done) => {
         const config = {
           hashKey: 'email',
           schema: {
@@ -2129,7 +2133,7 @@ describe('table', () => {
       });
     });
 
-    it('#destroy should call after hook', done => {
+    it('#destroy should call after hook', (done) => {
       const config = {
         hashKey: 'email',
         schema: {

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -44,7 +44,7 @@ exports.mockDocClient = () => {
     'query'
   ];
 
-  _.each(operations, op => {
+  _.each(operations, (op) => {
     client[op] = sinon.stub();
   });
 


### PR DESCRIPTION
Upgrades eslint and related packages to the latest versions available.  This fixes three of the bitHound dependency tests (#148).  I will be preparing another PR to deal with the remaining five tests, but since this is a fairly far-reaching set of changes, I wanted this one to be reviewed separately.

New warnings either in eslint or in eslint-config-airbnb-base were subsequently triggered and resolved as follows:

* prefer-destructuring: Disabled. IMO, applying this rule is silly and results in intentionally-obtuse code.
* no-multi-assign: Disabled. There are many places where we publish functions on `exports` and `internals` simultaneously using chained assignments (`a = b = c;`).  IMO, this is useful and makes the code clearer.
* prefer-spread: Disabled. The spread operator is not supported until Node 6, and we support back to Node 4 according to the CI build.
* object-curly-newline: Tweaked rule from airbnb-base to remove minParameters; resolved resulting warnings by reformatting object literals to either all be one one line or have one attribute per line.
* arrow-parens: Resolved warnings. (`a => { }` forms changed to `(a) => { }`)
* function-paren-newline: Resolved warnings by reformatting some chained method calls to span multiple lines for improved clarity.
* import/newline-after-import: Resolved warnings by moving all non-require lines to follow require lines.
* no-buffer-constructor: Resolved warnings by changing the deprecated `new Buffer(...)` forms to `Buffer.from(...)`.
* indent: Resolved warnings by applying consistent indentation rules to the few sections of code that did not conform.
* no-mixed-operators: Resolved warnings by using parens to explicitly group mathematical operations between different operators.  (Particularly in forms like `a - b * c`, grouping like `a - (b * c)` makes the author's intent clear, even though that's what's happening anyway.)
* no-plusplus: Resolved warnings by changing all `x++` forms to `x += 1`.
* space-unary-ops: Resolved warnings by changing `typeof(x)` forms to `typeof x`.
* no-prototype-builtins: Resolved warnings by replacing `x.hasOwnProperty(y)` forms with `Object.prototype.hasOwnProperty.call(x, y)`.
* no-unused-vars: Resolved warnings by removing unused variable declarations.
* no-restricted-properties: Resolved warnings by replacing `x.__defineGetter__()` forms with equivalent `Object.defineProperty()` calls.
* no-useless-escape: Resolved warnings by removing unnecessary `\` characters in string literals.