### PR TITLE
Make joi a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "async": "2.5.0",
     "aws-sdk": "2.131.0",
-    "joi": "11.3.4",
     "lodash": "4.17.4",
     "uuid": "3.1.0"
   },
@@ -40,8 +39,12 @@
     "eslint-config-airbnb-base": "12.1.0",
     "eslint-plugin-import": "2.10.0",
     "istanbul": "^0.4.4",
+    "joi": "^11.3.4",
     "jscoverage": "^0.6.0",
     "mocha": "4.0.1",
     "sinon": "4.0.1"
+  },
+  "peerDependencies": {
+    "joi": "^11.3.4"
   }
 }


### PR DESCRIPTION
`joi` is used by both the library and the consumer - it is important for them to be the same version, so I believe it should be a peer dependency. I've had issues with discrepancies between versions in the past.