### PR TITLE
Bump lodash version to 4.17.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "async": "2.5.0",
     "aws-sdk": "2.131.0",
-    "lodash": "4.17.4",
+    "lodash": "4.17.10",
     "uuid": "3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Includes fix for `npm audit` vulnerability warning: https://nodesecurity.io/advisories/577

