### PR TITLE
Make aws-sdk a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   "license": "MIT",
   "dependencies": {
     "async": "2.5.0",
-    "aws-sdk": "2.131.0",
     "lodash": "4.17.4",
     "uuid": "3.1.0"
   },
   "devDependencies": {
+    "aws-sdk": "2.131.0",
     "chai": "4.1.2",
     "coveralls": "3.0.0",
     "eslint": "4.19.1",
@@ -45,6 +45,7 @@
     "sinon": "4.0.1"
   },
   "peerDependencies": {
+    "aws-sdk": "2.131.0",
     "joi": "^11.3.4"
   }
 }


### PR DESCRIPTION
Much like joi, aws-sdk is often required by both the library and the 
consumer so it also makes sense to be a peer dependency as well.