### PR TITLE
Allow setting a single attribute, as per documentation

### DIFF
--- a/lib/item.js
+++ b/lib/item.js
@@ -26,8 +26,12 @@ Item.prototype.get = function (key) {
   }
 };
 
-Item.prototype.set = function (params) {
-  this.attrs = _.merge({}, this.attrs, params);
+Item.prototype.set = function (paramsOrKey, value) {
+  if (_.isString(paramsOrKey)) {
+    this.attrs[paramsOrKey] = value;
+  } else {
+    this.attrs = _.merge({}, this.attrs, paramsOrKey);
+  }
 
   return this;
 };

--- a/test/item-test.js
+++ b/test/item-test.js
@@ -97,4 +97,20 @@ describe('item', () => {
       });
     });
   });
+
+  describe('#set', () => {
+    it('should set attributes', () => {
+      const item = new Item({});
+      item.set({ num: 1, name: 'foo' });
+      expect(item.get('num')).to.equal(1);
+      expect(item.get('name')).to.equal('foo');
+    });
+
+    it('should set a single key when provided a string and value', () => {
+      const item = new Item({});
+      item.set('num', 123);
+      expect(item.get('num')).to.equal(123);
+    });
+  });
 });
+


### PR DESCRIPTION
Addresses the first problem mentioned in #174 

This now works:

```js
draft.set('content', 'foo');
```

 