### PR TITLE
single aws-sdk bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "2.5.0",
-    "aws-sdk": "2.131.0",
+    "aws-sdk": "2.408.0",
     "lodash": "4.17.4",
     "uuid": "3.1.0"
   },


### PR DESCRIPTION
#### The reason for this bump... 
- I use secrets manager as well as dynogels, the problem is that dynogels has a hard version number, so when uploading to a lambda for instance using a service like serverless to deploy, the version overwrites the standard sdk that amazon installs. by bumping the version this allows you to use the latest and greatest. 