### PR TITLE
Add on Demand mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,29 @@ Account.config({dynamodb: dynamodb});
 dynogels.dynamoDriver(dynamodb);
 ```
 
+#### On-Demand Mode
+You can enable [On-Demand](https://aws.amazon.com/blogs/aws/amazon-dynamodb-on-demand-no-capacity-planning-and-pay-per-request-pricing/ ) mode by setting the `billingMode` schema attribute to `'PAY_PER_REQUEST'`.
+
+```js
+const Event = dynogels.define('Event', {
+  hashKey : 'id',
+  schema : {
+    id : Joi.string()
+  },
+  billingMode: 'PAY_PER_REQUEST'
+});
+```
+
+Alternatively, set the billing mode in dynogels.createTables options. E.g.,
+
+```js
+dynogels.createTables({
+  'BlogPost': {
+    billingMode: 'PAY_PER_REQUEST'
+  }
+);
+```
+
 ### Saving Models to DynamoDB
 With your models defined, we can start saving them to DynamoDB.
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -19,6 +19,7 @@ internals.secondaryIndexSchema = Joi.object().keys({
 internals.configSchema = Joi.object().keys({
   hashKey: Joi.string().required(),
   rangeKey: Joi.string(),
+  billingMode: Joi.string().valid('PAY_PER_REQUEST', 'PROVISIONED'),
   tableName: Joi.alternatives().try(Joi.string(), Joi.func()),
   indexes: Joi.array().items(internals.secondaryIndexSchema),
   schema: Joi.object(),
@@ -95,6 +96,7 @@ const Schema = module.exports = function (config) {
   this.secondaryIndexes = {};
   this.globalIndexes = {};
   this.validationOptions = config.validation;
+  this.billingMode = config.billingMode;
 
   const context = { hashKey: config.hashKey };
 

--- a/lib/table.js
+++ b/lib/table.js
@@ -559,14 +559,18 @@ internals.secondaryIndex = (schema, params) => {
 internals.globalIndex = (indexName, params) => {
   const projection = params.projection || { ProjectionType: 'ALL' };
 
-  return {
-    IndexName: indexName,
-    KeySchema: internals.keySchema(params.hashKey, params.rangeKey),
-    Projection: projection,
+  const provisionedThroughput = params.billingMode === 'PAY_PER_REQUEST' ? {} : {
     ProvisionedThroughput: {
       ReadCapacityUnits: params.readCapacity || 1,
       WriteCapacityUnits: params.writeCapacity || 1
     }
+  };
+
+  return {
+    IndexName: indexName,
+    KeySchema: internals.keySchema(params.hashKey, params.rangeKey),
+    Projection: projection,
+    ...provisionedThroughput
   };
 };
 
@@ -574,6 +578,7 @@ Table.prototype.dynamoCreateTableParams = function (options) {
   const self = this;
 
   const attributeDefinitions = [];
+  const billingMode = options.billingMode || self.schema.billingMode || 'PROVISIONED';
 
   attributeDefinitions.push(internals.attributeDefinition(self.schema, self.schema.hashKey));
 
@@ -599,7 +604,7 @@ Table.prototype.dynamoCreateTableParams = function (options) {
       attributeDefinitions.push(internals.attributeDefinition(self.schema, params.rangeKey));
     }
 
-    globalSecondaryIndexes.push(internals.globalIndex(indexName, params));
+    globalSecondaryIndexes.push(internals.globalIndex(indexName, { ...params, billingMode }));
   });
 
   const keySchema = internals.keySchema(self.schema.hashKey, self.schema.rangeKey);
@@ -608,11 +613,15 @@ Table.prototype.dynamoCreateTableParams = function (options) {
     AttributeDefinitions: attributeDefinitions,
     TableName: self.tableName(),
     KeySchema: keySchema,
-    ProvisionedThroughput: {
+    BillingMode: billingMode
+  };
+
+  if (billingMode !== 'PAY_PER_REQUEST') {
+    params.ProvisionedThroughput = {
       ReadCapacityUnits: options.readCapacity || 1,
       WriteCapacityUnits: options.writeCapacity || 1
-    }
-  };
+    };
+  }
 
   if (localSecondaryIndexes.length >= 1) {
     params.LocalSecondaryIndexes = localSecondaryIndexes;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1526,9 +1526,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.get": {
       "version": "4.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1526,9 +1526,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash.get": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "license": "MIT",
   "dependencies": {
     "async": "2.5.0",
-    "aws-sdk": "^2.408.0",
-    "lodash": "^4.17.15",
+    "aws-sdk": "^2.441.0",
+    "lodash": "4.17.4",
     "uuid": "3.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "async": "2.5.0",
     "aws-sdk": "^2.441.0",
-    "lodash": "4.17.4",
+    "lodash": "^4.17.15",
     "uuid": "3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This adds a new schema attribute, billingMode, which can be set to 'PROVISIONED' (the default) or 'PAY_PER_REQUEST', which causes the table to run in On Demand mode. This value can also be provided on a per-table basis to the dynogels.createTables` function.

* Set billingMode as an attribute of the schema:

```js
const Account = dynogels.define('Account', {
  hashKey : 'id',
  schema : {
    id : Joi.string()
  },
  billingMode: 'PAY_PER_REQUEST'
});
```

* Pass it billingMode as a parameter to dynogels.createTables (overrides schema):

```js
dynogels.createTables({
  'Account': {
    billingMode: 'PAY_PER_REQUEST'
  }
}, function(err) {
  if (err) {
    console.log('Error creating tables: ', err);
  } else {
    console.log('Tables has been created');
  }
});
```

Fixes #182