### PR TITLE
Fix #185: Changing update function to update 'updatedAt'

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -310,7 +310,7 @@ Table.prototype.update = function (item, options, callback) {
   const start = (callback) => {
     const paramName = _.isString(self.schema.updatedAt) ? self.schema.updatedAt : 'updatedAt';
 
-    if (self.schema.timestamps && self.schema.updatedAt !== false && !_.has(item, paramName)) {
+    if (self.schema.timestamps && self.schema.updatedAt !== false && _.has(item, paramName)) {
       item[paramName] = new Date().toISOString();
     }
 


### PR DESCRIPTION
Fix for #185

There is a statement on line 313 of 'table.js' that looks for the 'updatedAt' field on a record. It is currently negated which causes dynogels to not update the field if it exists. By removing the negation this will cause the 'updatedAt' field to update correctly when the update function is called.